### PR TITLE
Install Midnight Commander

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -14,7 +14,7 @@ RUN mkdir -p /home/user && \
     # bash completion tools
     bash-completion ncurses pkgconf-pkg-config \
     # developer tools
-    curl git procps && \
+    curl git procps mc && \
     microdnf -y clean all && \
     # enable bash completion in interactive shells
     echo source /etc/profile.d/bash_completion.sh >> ~/.bashrc


### PR DESCRIPTION
### What does this PR do?
Install Midnight Commander - it terms of image size it's +6Mb

Before: 538 MB
After 544 MB

### Which issue does it reference/solve?
It's done in the scope of eclipse/che#16938

### It is tested?
There is built image locally 
`podman run -ti --rm --entrypoint bash sleshchenko/web-terminal-tooling:mc`
and 
by brew 
`podman run -ti --rm --entrypoint bash  registry-proxy.engineering.redhat.com/rh-osbs/web-terminal-web-terminal-tooling:web-terminal-1.0-rhel-8-containers-candidate-17962-20200624070037`. See job https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=29655192