### PR TITLE
Sync entrypoint with usual OpenShift requirements

### DIFF
--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -1,20 +1,22 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-USER_ID=$(id -u)
-GROUP_ID=$(id -g)
-export USER_ID
-export GROUP_ID
-
-if ! whoami >/dev/null 2>&1; then
-  echo "${USER_NAME:-user}:x:${USER_ID}:0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
-else
-  sed -i "s/\(.*:.*:${USER_ID}:${GROUP_ID}:.*:.*:\).*/\1\/bin\/bash/" /etc/passwd
+# Ensure $HOME exists when starting
+if [ ! -d "${HOME}" ]; then
+  mkdir -p "${HOME}"
 fi
 
-# Grant access to projects volume in case of non root user with sudo rights
-if [ "${USER_ID}" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
-    sudo chown "${USER_ID}:${GROUP_ID}" /projects
+# Setup $PS1 for a consistent and reasonable prompt
+if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
+  echo "PS1='\s-\v \w \$ '" >> "${HOME}"/.bashrc
+fi
+
+# Add current (arbitrary) user to /etc/passwd and /etc/group
+if ! whoami &> /dev/null; then
+  if [ -w /etc/passwd ]; then
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
+  fi
 fi
 
 exec "$@"

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -7,7 +7,7 @@ if [ ! -d "${HOME}" ]; then
 fi
 
 # Setup $PS1 for a consistent and reasonable prompt
-if [ -w "${HOME}" ] && [ ! -f "${HOME}"/.bashrc ]; then
+if [ -w "${HOME}" ] && [ -z "$PS1" ] && ! grep -q "PS1" "${HOME}/.bashrc"; then
   echo "PS1='\s-\v \w \$ '" >> "${HOME}"/.bashrc
 fi
 


### PR DESCRIPTION
There are issues with the current entrypoint. This PR basically copies the arbitrary user id patch entrypoint from the [`che-devfile-registry`](https://github.com/eclipse/che-devfile-registry/blob/master/arbitrary-users-patch/entrypoint.sh)

Note we don't need to worry about group ID -- on OpenShift user ID is set per pod and group ID is *always* 0. 