### PR TITLE
Enable ODCS

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -3,3 +3,8 @@
 platforms:
   only:
   - x86_64
+compose:
+  # configured empty packages makes the compose include all packages
+  # from the Koji build tag of the Koji build target.
+  packages: []
+  pulp_repos: true


### PR DESCRIPTION
### What does this PR do?

It enables ODCS to get signed rpms installed into a container.
Installed packages without transitive ones:
```
  bash-completion 
  ncurses 
  pkgconf-pkg-config
  curl
  git
  procps 
  mc 
```
Used repos:
```
ubi-8-baseos
ubi-8-appstream
rhel-8-for-appstream-rpms-pulp
rhel-8-for-baseos-rpms-pulp
```
<details>
<summary>See all installed RPMs</summary>

```
Installing:                                 
 bash-completion-1:2.7-5.el8.noarch                      rhel-8-for-baseos-rpms-pulp     280.2 kB
 cracklib-2.9.6-15.el8.x86_64                            ubi-8-baseos                     95.5 kB
 cracklib-dicts-2.9.6-15.el8.x86_64                      ubi-8-baseos                      4.1 MB
 emacs-filesystem-1:26.1-5.el8.noarch                    ubi-8-baseos                     71.1 kB
 fipscheck-1.5.0-4.el8.x86_64                            ubi-8-baseos                     28.2 kB
 fipscheck-lib-1.5.0-4.el8.x86_64                        ubi-8-baseos                     15.9 kB
 git-2.18.4-2.el8_2.x86_64                               ubi-8-appstream                 191.0 kB
 git-core-2.18.4-2.el8_2.x86_64                          ubi-8-appstream                   4.2 MB
 git-core-doc-2.18.4-2.el8_2.noarch                      ubi-8-appstream                   2.4 MB
 gpm-libs-1.20.7-15.el8.x86_64                           ubi-8-appstream                  39.8 kB
 groff-base-1.22.3-18.el8.x86_64                         ubi-8-baseos                      1.1 MB
 gzip-1.9-9.el8.x86_64                                   ubi-8-baseos                    170.9 kB
 less-530-1.el8.x86_64                                   ubi-8-baseos                    168.1 kB
 libedit-3.1-23.20170329cvs.el8.x86_64                   ubi-8-baseos                    104.5 kB
 libfdisk-2.32.1-22.el8.x86_64                           ubi-8-baseos                    254.6 kB
 libpkgconf-1.4.2-1.el8.x86_64                           ubi-8-baseos                     35.6 kB
 libpwquality-1.4.0-9.el8.x86_64                         ubi-8-baseos                    105.0 kB
 libsecret-0.18.6-1.el8.x86_64                           ubi-8-baseos                    166.9 kB
 libsemanage-2.9-2.el8.x86_64                            ubi-8-baseos                    168.3 kB
 libutempter-1.1.6-14.el8.x86_64                         ubi-8-baseos                     32.6 kB
 mc-1:4.8.19-9.el8.x86_64                                rhel-8-for-appstream-rpms-pulp    2.0 MB
 ncurses-6.1-7.20180224.el8.x86_64                       ubi-8-baseos                    396.4 kB
 openssh-8.0p1-4.el8_1.x86_64                            ubi-8-baseos                    507.9 kB
 openssh-clients-8.0p1-4.el8_1.x86_64                    ubi-8-baseos                    720.7 kB
 openssl-1:1.1.1c-15.el8.x86_64                          ubi-8-baseos                    713.7 kB
 pam-1.3.1-8.el8.x86_64                                  ubi-8-baseos                    750.5 kB
 perl-Carp-1.42-396.el8.noarch                           ubi-8-baseos                     30.9 kB
 perl-Data-Dumper-2.167-399.el8.x86_64                   ubi-8-baseos                     59.4 kB
 perl-Digest-1.17-395.el8.noarch                         ubi-8-appstream                  27.6 kB
 perl-Digest-MD5-2.55-396.el8.x86_64                     ubi-8-appstream                  37.9 kB
 perl-Encode-4:2.97-3.el8.x86_64                         ubi-8-baseos                      1.5 MB
 perl-Errno-1.28-416.el8.x86_64                          ubi-8-baseos                     77.5 kB
 perl-Error-1:0.17025-2.el8.noarch                       ubi-8-appstream                  47.2 kB
 perl-Exporter-5.72-396.el8.noarch                       ubi-8-baseos                     34.8 kB
 perl-File-Path-2.15-2.el8.noarch                        ubi-8-baseos                     39.0 kB
 perl-File-Temp-0.230.600-1.el8.noarch                   ubi-8-baseos                     64.1 kB
 perl-Getopt-Long-1:2.50-4.el8.noarch                    ubi-8-baseos                     64.5 kB
 perl-Git-2.18.4-2.el8_2.noarch                          ubi-8-appstream                  79.2 kB
 perl-HTTP-Tiny-0.074-1.el8.noarch                       ubi-8-baseos                     59.6 kB
 perl-IO-1.38-416.el8.x86_64                             ubi-8-baseos                    144.8 kB
 perl-IO-Socket-IP-0.39-5.el8.noarch                     ubi-8-appstream                  48.0 kB
 perl-IO-Socket-SSL-2.066-4.el8.noarch                   ubi-8-appstream                 304.7 kB
 perl-MIME-Base64-3.15-396.el8.x86_64                    ubi-8-baseos                     31.4 kB
 perl-Mozilla-CA-20160104-7.el8.noarch                   ubi-8-appstream                  15.7 kB
 perl-Net-SSLeay-1.88-1.el8.x86_64                       ubi-8-appstream                 388.0 kB
 perl-PathTools-3.74-1.el8.x86_64                        ubi-8-baseos                     92.2 kB
 perl-Pod-Escapes-1:1.07-395.el8.noarch                  ubi-8-baseos                     21.0 kB
 perl-Pod-Perldoc-3.28-396.el8.noarch                    ubi-8-baseos                     90.2 kB
 perl-Pod-Simple-1:3.35-395.el8.noarch                   ubi-8-baseos                    218.3 kB
 perl-Pod-Usage-4:1.69-395.el8.noarch                    ubi-8-baseos                     35.3 kB
 perl-Scalar-List-Utils-3:1.49-2.el8.x86_64              ubi-8-baseos                     69.4 kB
 perl-Socket-4:2.027-3.el8.x86_64                        ubi-8-baseos                     60.2 kB
 perl-Storable-1:3.11-3.el8.x86_64                       ubi-8-baseos                    100.7 kB
 perl-Term-ANSIColor-4.06-396.el8.noarch                 ubi-8-baseos                     47.1 kB
 perl-Term-Cap-1.17-395.el8.noarch                       ubi-8-baseos                     23.4 kB
 perl-TermReadKey-2.37-7.el8.x86_64                      ubi-8-appstream                  41.2 kB
 perl-Text-ParseWords-3.30-395.el8.noarch                ubi-8-baseos                     18.4 kB
 perl-Text-Tabs+Wrap-2013.0523-395.el8.noarch            ubi-8-baseos                     24.7 kB
 perl-Time-Local-1:1.280-1.el8.noarch                    ubi-8-baseos                     34.3 kB
 perl-URI-1.73-3.el8.noarch                              ubi-8-appstream                 118.9 kB
 perl-Unicode-Normalize-1.25-396.el8.x86_64              ubi-8-baseos                     83.8 kB
 perl-constant-1.33-396.el8.noarch                       ubi-8-baseos                     26.0 kB
 perl-interpreter-4:5.26.3-416.el8.x86_64                ubi-8-baseos                      6.6 MB
 perl-libnet-3.11-3.el8.noarch                           ubi-8-appstream                 123.8 kB
 perl-libs-4:5.26.3-416.el8.x86_64                       ubi-8-baseos                      1.6 MB
 perl-macros-4:5.26.3-416.el8.x86_64                     ubi-8-baseos                     73.4 kB
 perl-parent-1:0.237-1.el8.noarch                        ubi-8-baseos                     20.5 kB
 perl-podlators-4.11-1.el8.noarch                        ubi-8-baseos                    120.8 kB
 perl-threads-1:2.21-2.el8.x86_64                        ubi-8-baseos                     62.7 kB
 perl-threads-shared-1.58-2.el8.x86_64                   ubi-8-baseos                     48.8 kB
 pkgconf-1.4.2-1.el8.x86_64                              ubi-8-baseos                     39.0 kB
 pkgconf-m4-1.4.2-1.el8.noarch                           ubi-8-baseos                     17.5 kB
 pkgconf-pkg-config-1.4.2-1.el8.x86_64                   ubi-8-baseos                     15.6 kB
 procps-ng-3.3.15-1.el8.x86_64                           ubi-8-baseos                    336.1 kB
 shadow-utils-2:4.6-8.el8.x86_64                         ubi-8-baseos                      1.3 MB
 slang-2.3.2-3.el8.x86_64                                rhel-8-for-baseos-rpms-pulp     377.3 kB
 util-linux-2.32.1-22.el8.x86_64                         ubi-8-baseos                      2.6 MB
```

</details>

:warning: as an alternative we could remove packages from compose at all, it's the way that is used in CRW Theia http://pkgs.devel.redhat.com/cgit/containers/codeready-workspaces-theia/tree/container.yaml?h=crw-2.2-rhel-8#n11

Both ways should work but I'm not sure which are the best.


### Which does this PR references?
It fixes failed `unsigned_rpm_check` described in https://issues.redhat.com/browse/WTO-15