### PR TITLE
[base] Update from ubi8-minimal:8.2-301 to ubi8-minimal:8.2-339

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -1,6 +1,6 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-#@local FROM registry.access.redhat.com/ubi8-minimal:8.2-301
-#@Brew FROM ubi8-minimal:8.2-301
+#@local FROM registry.access.redhat.com/ubi8-minimal:8.2-339
+#@Brew FROM ubi8-minimal:8.2-339
 USER 0
 ENV HOME=/home/user
 WORKDIR /home/user


### PR DESCRIPTION
This PR updates base image from ubi8-minimal:8.2-301 to ubi8-minimal:8.2-339

It's done by https://github.com/redhat-developer/codeready-workspaces/blob/master/product/updateBaseImages.sh
Use command
```
../codeready-workspaces/product/updateBaseImages.sh -b updateBaseImage -w ./build -f template.Dockerfile
```
Note if you want to try it - you must `docker login registry.redhat.io` first. I spent some time to understand why script says - there is not newer base image found. Probably I'll prepare some PR to fail script earlier if failed to check because of missing logged in.

I'm going to set up some Job in future to update it automatically.