### PR TITLE
Fix /etc/group permissions issue

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -37,7 +37,7 @@ RUN \
     tkn completion bash > $COMPDIR/tkn
 
 # Change permissions to let any arbitrary user
-RUN for f in "${HOME}" "/etc/passwd"; do \
+RUN for f in "${HOME}" "/etc/passwd" "/etc/group"; do \
       echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
       chmod -R g+rwX ${f}; \
     done


### PR DESCRIPTION
### What does this PR do?
Fixes permissions issue

### Which issues does this PR resolves?
https://issues.redhat.com/browse/WTO-32

### How to test this PR?
```bash
# 1. install devworkspace controller or web terminal operator
# 2 
cat <<EOF | oc apply -f -
kind: DevWorkspace
apiVersion: workspace.devfile.io/v1alpha1
metadata:
  name: web-terminal
  annotations:
    # it's important to make workspace immutable to make sure nobody with right access
    # won't set custom editor to steal creator's token
    controller.devfile.io/restricted-access: "true"
  labels:
    # it's a label OpenShift console uses a flag to mark terminal's workspaces
    console.openshift.io/terminal: "true"
spec:
  started: true
  routingClass: 'web-terminal'
  template:
    components:
      - plugin:
          name: web-terminal
          id: redhat-developer/web-terminal/4.5.0
      - container:
          memoryLimit: "256Mi"
          name: tooling
          image: quay.io/sleshche/web-terminal-tooling:with-group
          args: ["tail", "-f", "/dev/null"]
          env:
            - name: PS1
              value: \[\e[34m\]>\[\e[m\]\[\e[33m\]>\[\e[m\]
EOF

# 3 make sure workspace is started
# 4 test that you're able to exec into tooling container of workspace pod
```