### PR TITLE
Add in rh-manifests.txt file so that all dependencies are tracked

### DIFF
--- a/get-sources-jenkins.sh
+++ b/get-sources-jenkins.sh
@@ -99,4 +99,16 @@ if [[ "$updateSourcesFlag" = "true" ]]; then
   rhpkg new-sources container-root-x86_64.tgz
 fi
 
+rm -f rh-manifests.txt || true
+{
+  echo "oc ${OC_VER} ${OPENSHIFT_CLIENTS_URL}/ocp/${OC_VER}"
+  echo "kubectl ${OC_VER} ${OPENSHIFT_CLIENTS_URL}/ocp/${OC_VER}"
+  echo "helm ${HELM_VER} ${OPENSHIFT_CLIENTS_URL}/helm/${HELM_VER}"
+  echo "odo ${ODO_VER} ${OPENSHIFT_CLIENTS_URL}/odo/${ODO_VER}"
+  echo "tekton ${TKN_VER} ${OPENSHIFT_CLIENTS_URL}/pipeline/${TKN_VER}"
+  echo "knative ${KN_VER} ${OPENSHIFT_CLIENTS_URL}/serverless/${KN_VER}"
+  echo "kubectx ${KUBECTX_VERSION} https://github.com/ahmetb/kubectx/tree/${KUBECTX_VERSION}"
+  echo "kubens ${KUBECTX_VERSION} https://github.com/ahmetb/kubectx/tree/${KUBECTX_VERSION}"
+} >> rh-manifests.txt
+
 rm -rf "$CONTAINER_ROOT_DIR"

--- a/rh-manifests.txt
+++ b/rh-manifests.txt
@@ -1,0 +1,8 @@
+oc 4.5.3 https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.3
+kubectl 4.5.3 https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.5.3
+helm 3.2.3 https://mirror.openshift.com/pub/openshift-v4/clients/helm/3.2.3
+odo v1.2.4 https://mirror.openshift.com/pub/openshift-v4/clients/odo/v1.2.4
+tekton 0.9.0 https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.9.0
+knative 0.13.2 https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.13.2
+kubectx v0.9.1 https://github.com/ahmetb/kubectx
+kubens v0.9.1 https://github.com/ahmetb/kubectx


### PR DESCRIPTION
This PR adds in a rh-manifests.txt file according to https://mojo.redhat.com/docs/DOC-1195158 for container-first non-golang dependencies. The rh-manifests.txt file will be updated every time we update container-root-x86_64.tgz so that everything is in sync.

From that doc its not entirely clear if we should be linking to the upstream ocp, tekton, odo, etc cli's github repos or from where we get them from (https://mirror.openshift.com/pub/openshift-v4/clients/)

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>