### PR TITLE
🚧 Do not override PS1

### DIFF
--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -6,11 +6,6 @@ if [ ! -d "${HOME}" ]; then
   mkdir -p "${HOME}"
 fi
 
-# Setup $PS1 for a consistent and reasonable prompt
-if [ -w "${HOME}" ] && [ -z "$PS1" ] && ! grep -q "PS1" "${HOME}/.bashrc"; then
-  echo "PS1='\s-\v \w \$ '" >> "${HOME}"/.bashrc
-fi
-
 # Add current (arbitrary) user to /etc/passwd and /etc/group
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then


### PR DESCRIPTION
### What does this PR do?
This PR removes the overriding of PS1.
From the code perspective of view, the condition should init PS1 only if there is no one defined, but in real life, PS1 is not available to read from entrypoint.sh. See that PS1, PS2, PS3, PS4 has different values for user terminal and script
```bash
bash-4.4 ~ $ cat test.sh    
echo "PS1 = $PS1"
echo "PS2 = $PS2"
echo "PS3 = $PS3"
echo "PS4 = $PS4"
bash-4.4 ~ $ ./test.sh 
PS1 = 
PS2 = 
PS3 = 
PS4 = + 
bash-4.4 ~ $ echo "PS1 = $PS1"
PS1 = \s-\v \w $ 
bash-4.4 ~ $ echo "PS2 = $PS2"
PS2 = > 
bash-4.4 ~ $ echo "PS3 = $PS3"
PS3 = 
bash-4.4 ~ $ echo "PS4 = $PS4"
PS4 = + 
bash-4.4 ~ $
```

So, if we don't override PS1 then we'll fall back to the default one which is not too bad:
```bash
bash-4.4$ echo $PS1
\s-\v\$
```

:warning: It does not solve an issue with prompt for Web Terminal fully, it's because of the command that is used to initialize terminal:
![Screenshot_20200818_175756](https://user-images.githubusercontent.com/5887312/90530163-3d126a00-e17d-11ea-9f7f-dc22553f2f7f.png)

So, probably changes are needed on the Web Terminal Exec side and command should be resolved as `/bin/bash` instead of `/bin/bash -c /bin/bash`, but I'm not sure. It needs additional investigating.

it has 🚧 since there is no agreement on the PR's changes and probably it will be just closed.

### Which issue does this PR reference?
It's related to https://issues.redhat.com/browse/WTO-40 but does not resolve it.