### PR TITLE
Add common terminal-based editors to image and set default

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir -p /home/user && \
     microdnf install -y \
     # bash completion tools
     bash-completion ncurses pkgconf-pkg-config \
+    # terminal-based editors
+    vi vim nano \
     # developer tools
     curl git procps mc && \
     microdnf -y clean all && \

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -8,7 +8,12 @@ fi
 
 # Setup $PS1 for a consistent and reasonable prompt
 if [ -w "${HOME}" ] && [ -z "$PS1" ] && ! grep -q "PS1" "${HOME}/.bashrc"; then
-  echo "PS1='\s-\v \w \$ '" >> "${HOME}"/.bashrc
+  echo "PS1='\s-\v \w \$ '" >> "${HOME}/.bashrc"
+fi
+
+# Set default editor to vim instead of fallback vi
+if [ -w "${HOME}" ] && ! grep -q "EDITOR" "${HOME}/.bashrc"; then
+  echo "EDITOR=vim" >> "${HOME}/.bashrc"
 fi
 
 # Add current (arbitrary) user to /etc/passwd and /etc/group


### PR DESCRIPTION
Add `vim`, `vi`, and `nano` to the image to enable commands like `kubectl edit`, and set the default editor to vim in `.bashrc` (as `vi` is used as a fallback when no `EDITOR`/`KUBE_EDITOR` var is set).
