### PR TITLE
Add --mode flag to build.sh as mentioned in help

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -41,6 +41,10 @@ function parse_arguments() {
             updateBinariesTgz="true"
             shift 0
             ;;
+            '--mode')
+            MODE="$2"
+            shift 1
+            ;;
             '--help')
             print_usage
             exit 0


### PR DESCRIPTION
The `./bulld.sh --help` output lists `--mode` as a command-line option, but it's not implemented except as an env var.