### PR TITLE
Update template.Dockerfile to newer ubi8-minimal tag

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -1,6 +1,6 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-#@local FROM registry.access.redhat.com/ubi8-minimal:8.2-345
-#@Brew FROM ubi8-minimal:8.2-345
+#@local FROM registry.access.redhat.com/ubi8-minimal:8.2-349
+#@Brew FROM ubi8-minimal:8.2-349
 USER 0
 ENV HOME=/home/user
 WORKDIR /home/user


### PR DESCRIPTION
This PR updates the default image inside of the template so that when the sync with dist-git everything is updated correctly

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>