### PR TITLE
Include xterm-resize in tooling container

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -1,6 +1,6 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-#@local FROM registry.access.redhat.com/ubi8-minimal:8.2-349
-#@Brew FROM ubi8-minimal:8.2-349
+#@local FROM registry.access.redhat.com/ubi8-minimal:8.3-201
+#@Brew FROM ubi8-minimal:8.3-201
 USER 0
 ENV HOME=/home/user
 ENV INITIAL_CONFIG=/tmp/initial_config

--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -17,7 +17,9 @@ RUN mkdir -p /home/user $INITIAL_CONFIG && \
     # terminal-based editors
     vi vim nano \
     # developer tools
-    curl git procps mc jq && \
+    curl git procps mc jq \
+    # other terminal tools
+    xterm-resize && \
     microdnf -y clean all && \
     # enable bash completion in interactive shells
     echo source /etc/profile.d/bash_completion.sh >> "${INITIAL_CONFIG}/.bashrc"


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/WTO-53. Essentially the idea is that resize is called before the terminal is opened by openshift console. Then when the terminal is opened the terminal size will be set correctly