### PR TITLE
Update tooling which corresponds to OpenShift 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Default OpenShift Console Web Terminal tooling container.
 
 Includes tools that a Kubernetes and OpenShift developer would like find in their terminal:
 - [jq](https://github.com/stedolan/jq)
-- [oc](https://github.com/openshift/origin) [4.6.1](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1/)
-- [kubectl](https://github.com/kubernetes/kubectl) [v1.19.0](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1/)
-- [odo](https://github.com/openshift/odo) [v2.0.0](https://mirror.openshift.com/pub/openshift-v4/clients/odo/v2.0.0/)
-- [helm](https://helm.sh/) [v3.3.4](https://mirror.openshift.com/pub/openshift-v4/clients/helm/3.3.4/)
-- [KNative](https://github.com/knative/client) [v0.16.1](https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.16.1/)
-- [Tekton CLI](https://github.com/tektoncd/cli) [0.11.0](https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.11.0/)
-- [kubectx & kubens](https://github.com/ahmetb/kubectx) [v0.9.1](https://github.com/ahmetb/kubectx/releases/tag/v0.9.1)
+- [oc](https://github.com/openshift/origin) [4.7.0](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.7.0)
+- [kubectl](https://github.com/kubernetes/kubectl) [v1.20.1](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.7.0)
+- [odo](https://github.com/openshift/odo) [v2.0.4](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/odo/v2.0.4)
+- [helm](https://helm.sh/) [3.5.0](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/helm/3.5.0)
+- [KNative](https://github.com/knative/client) [v0.19.1](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/serverless/0.19.1)
+- [Tekton CLI](https://github.com/tektoncd/cli) [0.15.0](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/pipeline/0.15.0)
+- [kubectx & kubens](https://github.com/ahmetb/kubectx) [v0.9.2](https://github.com/ahmetb/kubectx/releases/tag/v0.9.2)
 
 ## Contributing
 

--- a/rh-manifests.txt
+++ b/rh-manifests.txt
@@ -1,8 +1,8 @@
-oc 4.6.1 https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1
-kubectl 4.6.1 https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.6.1
-helm 3.3.4 https://mirror.openshift.com/pub/openshift-v4/clients/helm/3.3.4
-odo v2.0.0 https://mirror.openshift.com/pub/openshift-v4/clients/odo/v2.0.0
-tekton 0.11.0 https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.11.0
-knative 0.16.1 https://mirror.openshift.com/pub/openshift-v4/clients/serverless/0.16.1
-kubectx v0.9.1 https://github.com/ahmetb/kubectx/tree/v0.9.1
-kubens v0.9.1 https://github.com/ahmetb/kubectx/tree/v0.9.1
+oc 4.7.0 https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.7.0
+kubectl v1.20.1 https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.7.0
+helm 3.5.0 https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/helm/3.5.0
+odo v2.0.4 https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/odo/v2.0.4
+tekton 0.15.0 https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/pipeline/0.15.0
+knative 0.19.1 https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/serverless/0.19.1
+kubectx v0.9.2 https://github.com/ahmetb/kubectx/tree/v0.9.2
+kubens v0.9.2 https://github.com/ahmetb/kubectx/tree/v0.9.2


### PR DESCRIPTION
Update tooling which corresponds to OpenShift 4.7

If you want to test build image, I've pushed quay.io/sleshche/web-terminal-tooling:1.2.0