### PR TITLE
Support a mounted $HOME directory without removing config

### DIFF
--- a/content_sets_rhel8.repo
+++ b/content_sets_rhel8.repo
@@ -1,11 +1,11 @@
 [rhel-8-for-appstream-rpms-pulp]
 name=rhel-8-appstream-rpms-pulp
-baseurl=http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel8/8/$basearch/appstream/os
+baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/appstream/os
 enabled=1
 gpgcheck=0
 
 [rhel-8-for-baseos-rpms-pulp]
 name=rhel-8-baseos-rpms-pulp
-baseurl=http://pulp.dist.prod.ext.phx2.redhat.com/content/dist/rhel8/8/$basearch/baseos/os
+baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/baseos/os
 enabled=1
 gpgcheck=0

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -7,13 +7,13 @@ if [ ! -d "${HOME}" ]; then
 fi
 
 # Setup $PS1 for a consistent and reasonable prompt
-if [ -w "${HOME}" ] && [ -z "$PS1" ] && ! grep -q "PS1" "${HOME}/.bashrc"; then
-  echo "PS1='\s-\v \w \$ '" >> "${HOME}/.bashrc"
+if [ -w "${INITIAL_CONFIG}" ] && [ -z "$PS1" ] && ! grep -q "PS1" "${INITIAL_CONFIG}/.bashrc"; then
+  echo "PS1='\s-\v \w \$ '" >> "${INITIAL_CONFIG}/.bashrc"
 fi
 
 # Set default editor to vim instead of fallback vi
-if [ -w "${HOME}" ] && ! grep -q "EDITOR" "${HOME}/.bashrc"; then
-  echo "EDITOR=vim" >> "${HOME}/.bashrc"
+if [ -w "${INITIAL_CONFIG}" ] && ! grep -q "EDITOR" "${INITIAL_CONFIG}/.bashrc"; then
+  echo "EDITOR=vim" >> "${INITIAL_CONFIG}/.bashrc"
 fi
 
 # Add current (arbitrary) user to /etc/passwd and /etc/group
@@ -23,5 +23,7 @@ if ! whoami &> /dev/null; then
     echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
   fi
 fi
+
+find "$INITIAL_CONFIG" -mindepth 1 -exec cp -nrp {} "${HOME}/" \;
 
 exec "$@"

--- a/get-sources-jenkins.sh
+++ b/get-sources-jenkins.sh
@@ -49,8 +49,7 @@ curl -sSfL --insecure --remote-name-all \
 echo "$(grep openshift-client-linux-${OC_VER}.tar.gz sha256sum.txt | cut -d' ' -f1) openshift-client-linux-${OC_VER}.tar.gz" | sha256sum --check --status
 tar xzf openshift-client-linux-${OC_VER}.tar.gz -C "$CONTAINER_USR_BIN_DIR" oc kubectl
 
-KUBECTL_V=$($CONTAINER_USR_BIN_DIR/kubectl version --client=true -o=json | jq -r '.clientVersion.gitVersion
-')
+KUBECTL_V=$($CONTAINER_USR_BIN_DIR/kubectl version --client=true -o=json | jq -r '.clientVersion.gitVersion')
 # Kubectl version has vMajor.Manor.BugFix-Build-GitRevision, like v1.20.1-5-g76a04fc
 # Cut build number and git revision
 KUBECTL_VER=${KUBECTL_V%-*-*}
@@ -79,7 +78,7 @@ curl -sSfL --insecure --remote-name-all \
   ${OPENSHIFT_CLIENTS_URL}/pipeline/${TKN_VER}/sha256sum.txt \
   ${OPENSHIFT_CLIENTS_URL}/pipeline/${TKN_VER}/tkn-linux-amd64-${TKN_VER}.tar.gz
 echo "$(grep tkn-linux-amd64-${TKN_VER}.tar.gz sha256sum.txt | cut -d' ' -f1) tkn-linux-amd64-${TKN_VER}.tar.gz" | sha256sum --check --status
-tar xzf tkn-linux-amd64-${TKN_VER}.tar.gz -C "$CONTAINER_USR_BIN_DIR" ./tkn
+tar xzf tkn-linux-amd64-${TKN_VER}.tar.gz -C "$CONTAINER_USR_BIN_DIR" tkn
 rm -rf "${TMPDIR:?}"/*
 
 echo "Downloading knative ${KN_VER}"


### PR DESCRIPTION
When a directory is mounted to $HOME, all files in that directory are replaced with the persistent volume. To avoid this, instead put all pre-created $HOME files in an initial config directory and copy them to $HOME on start. If files already exist, they are not copied.

Also:
* Fixes issue extracting tekton binary (extracting './tkn' vs extracting 'tkn')
* Adds 'jq' binary to tooling image, as it is currently missing

Fixes https://issues.redhat.com/browse/WTO-82