### PR TITLE
Update template to use newest 8.3 images

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -1,6 +1,6 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-#@local FROM registry.access.redhat.com/ubi8-minimal:8.2-349
-#@Brew FROM ubi8-minimal:8.2-349
+#@local FROM registry.access.redhat.com/ubi8-minimal:8.3-298
+#@Brew FROM ubi8-minimal:8.3-298
 USER 0
 ENV HOME=/home/user
 ENV INITIAL_CONFIG=/tmp/initial_config


### PR DESCRIPTION
This PR updates the base image to use the newest 8.3 image. The script we use only updates the base image to newer versions of 8.2, that's why we need to update manually

Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>