### PR TITLE
Add welcome message and help alias

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -20,9 +20,7 @@ RUN mkdir -p /home/user $INITIAL_CONFIG && \
     # developer tools
 #@brew     mc \
     curl git procps jq && \
-    microdnf -y clean all && \
-    # enable bash completion in interactive shells
-    echo source /etc/profile.d/bash_completion.sh >> "${INITIAL_CONFIG}/.bashrc"
+    microdnf -y clean all
 
 ADD container-root-x86_64.tgz /
 # Propagate tools to path and install bash autocompletion
@@ -41,11 +39,12 @@ RUN \
     # Install oc & kubectl & odo && kn && helm && tkn
     kubectl completion bash > $COMPDIR/kubectl && \
     oc completion bash > $COMPDIR/oc && \
-    printf "complete -C /usr/local/bin/odo odo\n\n" >> "${INITIAL_CONFIG}/.bashrc" && \
     kn completion bash > $COMPDIR/kn && \
     helm completion bash > $COMPDIR/helm && \
     tkn completion bash > $COMPDIR/tkn
 
+COPY etc/initial_config /tmp/initial_config
+COPY tooling_versions.env /tmp/tooling_versions.env
 # Change permissions to let any arbitrary user
 RUN for f in "${HOME}" "${INITIAL_CONFIG}" "/etc/passwd" "/etc/group"; do \
     echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -11,11 +11,6 @@ if [ -w "${INITIAL_CONFIG}" ] && [ -z "$PS1" ] && ! grep -q "PS1" "${INITIAL_CON
   echo "PS1='\s-\v \w \$ '" >> "${INITIAL_CONFIG}/.bashrc"
 fi
 
-# Set default editor to vim instead of fallback vi
-if [ -w "${INITIAL_CONFIG}" ] && ! grep -q "EDITOR" "${INITIAL_CONFIG}/.bashrc"; then
-  echo "EDITOR=vim" >> "${INITIAL_CONFIG}/.bashrc"
-fi
-
 # Add current (arbitrary) user to /etc/passwd and /etc/group
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then

--- a/etc/initial_config/.bashrc
+++ b/etc/initial_config/.bashrc
@@ -1,0 +1,28 @@
+# Set default editor to vim instead of default fallback vi
+EDITOR=vim
+
+function help_message() {
+  source /tmp/tooling_versions.env
+  # Kubectl version isn't explicitly defined and instead matches oc version
+  KUBECTL_VER=$(kubectl version --client --short | sed 's|Client Version: ||')
+  cat <<EOF
+Installed tooling:
+  * jq
+  * oc $OC_VER
+  * kubectl $KUBECTL_VER
+  * odo $ODO_VER
+  * helm $HELM_VER
+  * KNative $KN_VER
+  * Tekton CLI $TKN_VER
+  * kubectx & kubens $KUBECTX_VERSION
+  * rhoas $RHOAS_VERSION
+  * submariner $SUBMARINER_VERSION
+EOF
+}
+
+alias help=help_message
+
+complete -C /usr/local/bin/odo odo
+source /etc/profile.d/bash_completion.sh
+
+echo 'Welcome to the OpenShift Web Terminal. Type "help" for a list of installed CLI tools.'

--- a/etc/initial_config/.bashrc
+++ b/etc/initial_config/.bashrc
@@ -5,18 +5,20 @@ function help_message() {
   source /tmp/tooling_versions.env
   # Kubectl version isn't explicitly defined and instead matches oc version
   KUBECTL_VER=$(kubectl version --client --short | sed 's|Client Version: ||')
+  JQ_VER=$(jq --version)
+  JQ_VER=${JQ_VER#jq-}
   cat <<EOF
 Installed tooling:
-  * jq
   * oc $OC_VER
   * kubectl $KUBECTL_VER
-  * odo $ODO_VER
   * helm $HELM_VER
-  * KNative $KN_VER
-  * Tekton CLI $TKN_VER
+  * kn (KNative CLI) $KN_VER
+  * tkn (Tekton CLI) $TKN_VER
+  * subctl (Submariner CLI) $SUBMARINER_VERSION
+  * odo (Red Hat OpenShift Developer CLI) $ODO_VER
+  * rhoas (Red Hat OpenShift Application Services CLI) $RHOAS_VERSION
   * kubectx & kubens $KUBECTX_VERSION
-  * rhoas $RHOAS_VERSION
-  * submariner $SUBMARINER_VERSION
+  * jq $JQ_VER
 EOF
 }
 

--- a/etc/initial_config/.bashrc
+++ b/etc/initial_config/.bashrc
@@ -1,24 +1,39 @@
 # Set default editor to vim instead of default fallback vi
 EDITOR=vim
 
+INSTALLED_TOOLS='Command\tVersion\tName
+oc $OC_VER
+kubectl $KUBECTL_VER
+helm $HELM_VER
+kn (KNative CLI) $KN_VER
+tkn (Tekton CLI) $TKN_VER
+subctl (Submariner CLI) $SUBMARINER_VERSION
+odo (Red Hat OpenShift Developer CLI) $ODO_VER
+rhoas (Red Hat OpenShift Application Services CLI) $RHOAS_VERSION
+kubectx & kubens $KUBECTX_VERSION
+jq $JQ_VER
+'
+
 function help_message() {
   source /tmp/tooling_versions.env
   # Kubectl version isn't explicitly defined and instead matches oc version
   KUBECTL_VER=$(kubectl version --client --short | sed 's|Client Version: ||')
   JQ_VER=$(jq --version)
   JQ_VER=${JQ_VER#jq-}
-  cat <<EOF
-Installed tooling:
-  * oc $OC_VER
-  * kubectl $KUBECTL_VER
-  * helm $HELM_VER
-  * kn (KNative CLI) $KN_VER
-  * tkn (Tekton CLI) $TKN_VER
-  * subctl (Submariner CLI) $SUBMARINER_VERSION
-  * odo (Red Hat OpenShift Developer CLI) $ODO_VER
-  * rhoas (Red Hat OpenShift Application Services CLI) $RHOAS_VERSION
-  * kubectx & kubens $KUBECTX_VERSION
-  * jq $JQ_VER
+
+  cat <<EOF | column -t -s '|'
+Command  |Version  |Name
+oc|$OC_VER|OpenShift CLI
+kubectl|$KUBECTL_VER|Kubernetes CLI
+helm|$HELM_VER|Helm CLI
+kn|$KN_VER|KNative CLI
+tkn|$TKN_VER|Tekton CLI
+subctl|$SUBMARINER_VERSION|Submariner CLI
+odo|$ODO_VER|Red Hat OpenShift Developer CLI
+rhoas|$RHOAS_VERSION|Red Hat OpenShift Application Services CLI
+kubectx|$KUBECTX_VERSION|Kubernetes Context CLI
+kubens|$KUBECTX_VERSION|Kubernetes Namespace CLI
+jq|$JQ_VER|jq
 EOF
 }
 


### PR DESCRIPTION
### Description
Add short welcome message when starting container, and add 'help' alias that prints out installed CLIs with their versions.

![web-terminal-1080](https://user-images.githubusercontent.com/16168279/157513255-c3bf5258-27e9-4222-934f-dac4be5cf5b5.png)

Using Chrome developer tools to simulate a 1280x720 resolution:
![web-terminal-720](https://user-images.githubusercontent.com/16168279/157513397-6983b961-619b-4275-be0c-9a1da5a59d8f.png)

### How to test
From any running Web Terminal, copy and paste the following command to make the terminal update itself to this PR:
```
kubectl get dw -o json \
  -n $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) \
  $DEVWORKSPACE_NAME \
  | jq '.spec.template.components[0].plugin.components = [{
      "name": "web-terminal-tooling",
      "container": {
        "image": "quay.io/amisevsk/web-terminal-tooling:welcome-message"
      }
    }]' \
  | kubectl apply -f -
```
Once executed, the terminal will restart with the new image and you should see the welcome message and be able to type `help` for more info.