### PR TITLE
Add 'wtoctl' utility to web terminal tooling image to enable configuring running web terminal

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -45,12 +45,14 @@ RUN \
 
 COPY etc/initial_config /tmp/initial_config
 COPY tooling_versions.env /tmp/tooling_versions.env
+COPY ["etc/wtoctl", "etc/wtoctl_help.sh", "etc/wtoctl_jq.sh", "/usr/local/bin/"]
+COPY etc/entrypoint.sh /entrypoint.sh
+
 # Change permissions to let any arbitrary user
 RUN for f in "${HOME}" "${INITIAL_CONFIG}" "/etc/passwd" "/etc/group"; do \
     echo "Changing permissions on ${f}" && chgrp -R 0 ${f} && \
     chmod -R g+rwX ${f}; \
     done
-COPY etc/entrypoint.sh /entrypoint.sh
 
 USER 1001
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/etc/initial_config/.bashrc
+++ b/etc/initial_config/.bashrc
@@ -1,19 +1,6 @@
 # Set default editor to vim instead of default fallback vi
 EDITOR=vim
 
-INSTALLED_TOOLS='Command\tVersion\tName
-oc $OC_VER
-kubectl $KUBECTL_VER
-helm $HELM_VER
-kn (KNative CLI) $KN_VER
-tkn (Tekton CLI) $TKN_VER
-subctl (Submariner CLI) $SUBMARINER_VERSION
-odo (Red Hat OpenShift Developer CLI) $ODO_VER
-rhoas (Red Hat OpenShift Application Services CLI) $RHOAS_VERSION
-kubectx & kubens $KUBECTX_VERSION
-jq $JQ_VER
-'
-
 function help_message() {
   source /tmp/tooling_versions.env
   # Kubectl version isn't explicitly defined and instead matches oc version
@@ -21,6 +8,7 @@ function help_message() {
   JQ_VER=$(jq --version)
   JQ_VER=${JQ_VER#jq-}
 
+  echo "Installed tools:"
   cat <<EOF | column -t -s '|'
 Command  |Version  |Name
 oc|$OC_VER|OpenShift CLI
@@ -35,6 +23,8 @@ kubectx|$KUBECTX_VERSION|Kubernetes Context CLI
 kubens|$KUBECTX_VERSION|Kubernetes Namespace CLI
 jq|$JQ_VER|jq
 EOF
+  echo ""
+  echo "To customize this terminal, see 'wtoctl'"
 }
 
 alias help=help_message

--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -1,0 +1,190 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+source "${SCRIPT_DIR}/wtoctl_help.sh"
+source "${SCRIPT_DIR}/wtoctl_jq.sh"
+
+NAMESPACE=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+DEVWORKSPACE_ID_LABEL="controller.devfile.io/devworkspace_id"
+
+if [[ $# -lt 1 ]]; then
+  general_help
+  exit 0
+fi
+
+function preflight_checks() {
+  # Verify that the current Web Terminal has the default components we expect
+  # Otherwise commands could fail in hard to understand ways
+  if ! grep -q 'name: web-terminal-exec' "$DEVWORKSPACE_FLATTENED_DEVFILE" ||
+     ! grep -q 'controller.devfile.io/imported-by: web-terminal-exec' "$DEVWORKSPACE_FLATTENED_DEVFILE" ||
+     ! grep -q 'name: web-terminal-tooling' "$DEVWORKSPACE_FLATTENED_DEVFILE" ||
+     ! grep -q 'controller.devfile.io/imported-by: web-terminal-tooling' "$DEVWORKSPACE_FLATTENED_DEVFILE"; then
+    echo "Current Web Terminal does not contain expected components -- wtoctl cannot operate on this Web Terminal"
+    exit 1
+  fi
+}
+
+function get_current_image() {
+  # Since we don't have `yq` installed in the tooling container, we have to grab the pod
+  # and read it from there
+  POD_JSON=$(oc get pods --namespace "$NAMESPACE" -l "$DEVWORKSPACE_ID_LABEL=$DEVWORKSPACE_ID" -o json)
+  CURR_IMAGE=$(echo "$POD_JSON" | jq -r '.items[0].spec.containers[] | select(.name == "web-terminal-tooling") | .image')
+  echo "$CURR_IMAGE"
+}
+
+function get_tooling_image() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Get image used for terminal"
+    echo "Usage: 'wtoctl get image'"
+    exit 0
+  fi
+  expect_no_args "wtoctl get image" "$@"
+  CURR_IMG=$(get_current_image)
+  echo "Current image is $CURR_IMG"
+}
+
+function set_tooling_image() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Set image used for terminal"
+    echo "Usage: 'wtoctl set image <image-name>'"
+    exit 0
+  fi
+  expect_one_arg "wtoctl set image" "$@"
+  local IMAGE="$1"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  UPDATED_JSON=$(echo "$DW_JSON" | jq --arg IMAGE "$IMAGE" "$JQ_SET_IMAGE_SCRIPT")
+  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "Updated Web Terminal image to $IMAGE. Terminal may restart."
+}
+
+function reset_tooling_image() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Reset image used for terminal to the default"
+    echo "Usage: 'wtoctl reset image'"
+    exit 0
+  fi
+  expect_no_args "wtoctl reset image" "$@"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  UPDATED_JSON=$(echo "$DW_JSON" | jq "$JQ_RESET_IMAGE_SCRIPT")
+  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "Reset Web Terminal tooling image, terminal may restart"
+}
+
+function get_timeout() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Get timeout used for terminal"
+    echo "Usage: 'wtoctl get timeout'"
+    exit 0
+  fi
+  expect_no_args "wtoctl get timeout" "$@"
+  POD_JSON=$(oc get pods --namespace "$NAMESPACE" -l "$DEVWORKSPACE_ID_LABEL=$DEVWORKSPACE_ID" -o json)
+  CURRENT_TIMEOUT=$(echo "$POD_JSON" | jq -r "$JQ_GET_TIMEOUT_SCRIPT")
+  echo "Current timeout is $CURRENT_TIMEOUT"
+}
+
+function set_timeout() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Set timeout used for terminal"
+    echo "Usage: 'wtoctl set timeout <timeout>'"
+    echo "See 'wtoctl timeout --help' for timeout format"
+    exit 0
+  fi
+  expect_one_arg "wtoctl set timeout" "$@"
+  local TIMEOUT="$1"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  UPDATED_JSON=$(echo "$DW_JSON" | jq --arg TIMEOUT "$TIMEOUT" "$JQ_SET_TIMEOUT_SCRIPT")
+  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "Updated Web Terminal idle timeout to $TIMEOUT. Terminal may restart."
+}
+
+function reset_timeout() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Reset idle timeout used for terminal to the default"
+    echo "Usage: 'wtoctl reset timeout'"
+    exit 0
+  fi
+  expect_no_args "wtoctl reset timeout" "$@"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  UPDATED_JSON=$(echo "$DW_JSON" | jq "$JQ_RESET_TIMEOUT_SCRIPT")
+  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "Reset Web Terminal idle timeout. Terminal may restart."
+}
+
+function do_get() {
+  if [[ $# -lt 1 ]]; then
+    echo "wtoctl get expects additional arguments. See 'wtoctl get --help' for more information"
+    exit 1
+  fi
+  case $1 in
+    "image")
+    get_tooling_image "${@:2}" ;;
+    "timeout")
+    get_timeout "${@:2}" ;;
+    "--help"|"help")
+    get_help ;;
+    *)
+    echo "Unknown option $1 for 'wtoctl get'"
+    echo "See 'wtoctl get --help' for usage."
+    exit 1
+  esac
+}
+
+function do_set() {
+  if [[ $# -lt 1 ]]; then
+    echo "wtoctl set expects additional arguments. See 'wtoctl set --help' for more information"
+    exit 1
+  fi
+  case $1 in
+    "image")
+    set_tooling_image "${@:2}" ;;
+    "timeout")
+    set_timeout "${@:2}" ;;
+    "--help"|"help")
+    set_help ;;
+    *)
+    echo "Unknown option $1 for 'wtoctl set'"
+    echo "See 'wtoctl set --help' for usage."
+    exit 1
+  esac
+}
+
+function do_reset() {
+  if [[ $# -lt 1 ]]; then
+    echo "wtoctl reset expects additional arguments. See 'wtoctl reset --help' for more information"
+    exit 1
+  fi
+  case $1 in
+    "image")
+      reset_tooling_image "${@:2}" ;;
+    "timeout")
+      reset_timeout "${@:2}" ;;
+    "--help"|"help")
+      reset_help ;;
+    *)
+    echo "Unknown option $1 for 'wtoctl reset'"
+    echo "See 'wtoctl reset --help' for usage."
+    exit 1
+  esac
+}
+
+preflight_checks
+
+case $1 in
+  "get")
+    do_get "${@:2}" ;;
+  "set")
+    do_set "${@:2}" ;;
+  "reset")
+    do_reset "${@:2}" ;;
+  "--help"|"help")
+    general_help ;;
+  "image")
+    help_or_error image_help "wtoctl image" "${@:2}" ;;
+  "timeout")
+    help_or_error timeout_help "wtoctl timeout" "${@:2}" ;;
+  *)
+    echo "Unknown command $1 for wtoctl"
+    echo "Run 'wtoctl --help' for usage"
+esac

--- a/etc/wtoctl_help.sh
+++ b/etc/wtoctl_help.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+function general_help() {
+  cat <<EOF
+wtoctl is a simple tool for customizing Web Terminals in OpenShift intended to
+be used within a running terminal instance.
+
+Configurable fields:
+  * image   - the image used for the terminal
+  * timeout - the time a Web Terminal may be idle before it is terminated
+
+Available commands:
+  * get   - get the current value for a field
+  * set   - set the current value for a field
+  * reset - reset a field to its default value
+
+Usage:
+  wtoctl <command> [options]
+
+Use wtoctl <command> --help for more information about a given command.
+Use wtoctl <field> --help for more information about a given field.
+
+To reset all changes and return to a default terminal, execute
+  oc delete devworkspace $DEVWORKSPACE_NAME --namespace $NAMESPACE
+and restart the Web Terminal
+EOF
+}
+
+function image_help() {
+  cat <<EOF
+The image field defines which container image is used to run the Web Terminal.
+By default, an image containing common cluster tooling is used, but this can be
+extended or replaced with a custom built image to include additional tools or
+configuration.
+
+It is recommended to extend the default image (see 'wtoctl get image') when
+building a custom tooling image to ensure configuration is correct.
+
+If a misconfigured image is used, the Web Terminal may fail to restart. If this
+occurs, the Web Terminal custom resource should be deleted by executing
+  oc delete devworkspace $DEVWORKSPACE_NAME --namespace $NAMESPACE
+EOF
+}
+
+function timeout_help() {
+  cat <<EOF
+The timeout field defines how long a Web Terminal should wait before shutting
+down when left idle. The duration should be specified as a number and unit
+suffix. Valid suffixes are "ms" (milliseconds), "s" (seconds), "m" (minutes),
+and "h" (hours). After the specified duration, the web terminal will shut down
+and need to be restarted the the next time it is accessed.
+
+It is not recommended to use very long durations for this value, as it will
+result in idle Web Terminals running for a long time.
+
+Examples:
+  * 15m   - 15 minutes
+  * 1h30m - 1 hour and 30 minutes
+  * 1.5h  - 1 hour and 30 minutes
+EOF
+}
+
+function get_help() {
+  cat <<EOF
+Gets the current value of a field
+
+Configurable fields:
+  * image   - the image used for the terminal
+  * timeout - the time a Web Terminal may be idle before it is terminated
+
+Usage:
+  wtoctl get <field>
+
+Use wtoctl <field> --help for more information about a given field.
+EOF
+}
+
+function set_help() {
+  cat <<EOF
+Sets a given field
+
+Configurable fields:
+  * image   - the image used for the terminal
+  * timeout - the time a Web Terminal may be idle before it is terminated
+
+Usage:
+  wtoctl set <field> <value>
+
+Use wtoctl <field> --help for more information about a given field.
+EOF
+}
+
+function reset_help() {
+  cat <<EOF
+Resets a given field to its default value
+
+Configurable fields:
+  * image   - the image used for the terminal
+  * timeout - the time a Web Terminal may be idle before it is terminated
+
+Usage:
+  wtoctl reset <field>
+
+Use wtoctl <field> --help for more information about a given field.
+EOF
+}
+
+function expect_no_args() {
+  CMD_REF="$1"; shift
+  if [[ $# -gt 0 ]]; then
+    echo "Unknown option '$*' for '$CMD_REF'"
+    echo "See '$CMD_REF --help' for usage"
+    exit 1
+  fi
+}
+
+function expect_one_arg() {
+  CMD_REF="$1"; shift
+  if [[ $# -eq 0 ]]; then
+    echo "Command '$CMD_REF' expects an argument"
+    echo "See '$CMD_REF --help' for usage."
+    exit 1
+  fi
+  if [[ $# -gt 1 ]]; then
+    echo "Command '$CMD_REF' expect only one argument"
+    echo "See '$CMD_REF --help' for usage."
+  fi
+}
+
+function help_or_error() {
+  local HELP_CMD="$1"; shift
+  local CMD_REF="$1"; shift
+  if [[ $# -eq 0 ]]; then $HELP_CMD; exit 0; fi
+  case $1 in
+    "--help"|"help")
+      $HELP_CMD ;;
+    *)
+      echo "Unknown option '$1' for '$CMD_REF'"
+      echo "See '$CMD_REF --help' for usage"
+      exit 1
+  esac
+}

--- a/etc/wtoctl_jq.sh
+++ b/etc/wtoctl_jq.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Set container image override for the web-terminal-tooling image in a
+# DevWorkspace. Expects argument $IMAGE to be the image to set.
+# shellcheck disable=SC2016
+export JQ_SET_IMAGE_SCRIPT='
+.spec.template.components = [.spec.template.components[] |
+  if .name == "web-terminal-tooling"
+  then
+    .plugin.components= [{
+      "name": "web-terminal-tooling",
+      "container": {
+        "image": $IMAGE
+      }
+    }]
+  else . end
+]
+'
+
+# Remove container image override for the web-terminal-tooling image in a
+# DevWorkspace
+export JQ_RESET_IMAGE_SCRIPT='
+.spec.template.components = [.spec.template.components[] |
+  if .name == "web-terminal-tooling"
+  then
+    del(.plugin.components)
+  else . end
+]
+'
+
+# Get current value of WEB_TERMINAL_IDLE_TIMEOUT env var from a PodList
+export JQ_GET_TIMEOUT_SCRIPT='
+.items[0].spec.containers[] |
+  select(.name == "web-terminal-exec") |
+  .env[] |
+  select(.name == "WEB_TERMINAL_IDLE_TIMEOUT") |
+  .value
+'
+
+# Set WEB_TERMINAL_IDLE_TIMEOUT env var in web-terminal-exec container on a
+# DevWorkspace. Expects argument $TIMEOUT to be the timeout to set
+export JQ_SET_TIMEOUT_SCRIPT='
+.spec.template.components = [.spec.template.components[] |
+  if .name == "web-terminal-exec"
+  then
+    .plugin.components= [{
+      "name": "web-terminal-exec",
+      "container": {
+        "env": [{
+          "name": "WEB_TERMINAL_IDLE_TIMEOUT",
+          "value": $TIMEOUT
+        }]
+      }
+    }]
+  else . end
+]
+'
+
+# Delete WEB_TERMINAL_IDLE_TIMEOUT env var override in web-terminal-exec
+# container on a DevWorkspace.
+export JQ_RESET_TIMEOUT_SCRIPT='
+.spec.template.components = [.spec.template.components[] |
+  if .name == "web-terminal-exec"
+  then
+    del(.plugin.components)
+  else . end
+]
+'


### PR DESCRIPTION
### Description
Adds small script `wtoctl` to Web Terminal tooling image which enables configuring a few things about the running web terminal. The tool comes with detailed help menus to enable easier use, and is capable of

* Configuring/resetting the tooling image used for the current Web Terminal
* Configuring/resetting the idle timeout for the current Web Terminal

![wtoctl-demo](https://user-images.githubusercontent.com/16168279/157967695-35e5c917-72f4-434d-b624-d82e8697f0d7.gif)

To test the image, execute
```bash
export IMAGE=quay.io/amisevsk/web-terminal-tooling:wtoctl
kubectl get dw -o json \
  -n $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) \
  $DEVWORKSPACE_NAME \
  | jq --arg IMAGE $IMAGE '.spec.template.components[0].plugin.components = [{
      "name": "web-terminal-tooling",
      "container": {
        "image": $IMAGE
      }
    }]' \
  | kubectl apply -f -
```
in a running Web Terminal (e.g. in the Developer Sandbox)

Note image `quay.io/amisevsk/web-terminal-tooling:wtoctl-2` is identical and can be used to test `wtoctl set image`
