### PR TITLE
Disable all repos except for UBI8 repos in local build

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -12,7 +12,10 @@ ENV HOME=/home/user
 WORKDIR /home/user
 
 RUN mkdir -p /home/user $INITIAL_CONFIG && \
-    microdnf install -y \
+#@local     microdnf update -y --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos && \
+#@local     microdnf install -y --disablerepo=* --enablerepo=ubi-8-appstream --enablerepo=ubi-8-baseos \
+#@brew     microdnf update -y && \
+#@brew     microdnf install -y \
     # bash completion tools
     bash-completion ncurses pkgconf-pkg-config findutils \
     # terminal-based editors


### PR DESCRIPTION
Disable additional repos when building the upstream (local) image to make sure accidentally adding RHEL-only packages is impossible. 

Docs reference: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index#proc_building-ubi-based-images_assembly_adding-software-to-a-running-ubi-container