### PR TITLE
Store bash history in tooling container

### DIFF
--- a/etc/initial_config/.bashrc
+++ b/etc/initial_config/.bashrc
@@ -30,4 +30,9 @@ alias help=help_message
 complete -C /usr/local/bin/odo odo
 source /etc/profile.d/bash_completion.sh
 
+# Since xterm doesn't save history on exit, we manually sync history on each command
+shopt -s histappend
+# Append lines from this session to history, clear the session's history, re-read the history file
+PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"
+
 echo 'Welcome to the OpenShift Web Terminal. Type "help" for a list of installed CLI tools.'


### PR DESCRIPTION
## Description
Since xterm.js does not save history on disconnecting, it's necessary to configure the tooling container to write history after every command. To do this, we set PROMPT_COMMAND to sync the current session with the
.bash_history file every time the prompt is printed.

This preserves history for the runtime of a web terminal pod. History is still lost whenever the pod is deleted or idled.

## Issue
Fix for https://issues.redhat.com/browse/WTO-126

## Additional Info
To test changes, paste the following in a runnin web terminal tab:
```bash
export IMAGE=quay.io/amisevsk/web-terminal-tooling:bash-history
kubectl get dw -o json \
  -n $(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace) \
  $DEVWORKSPACE_NAME \
  | jq --arg IMAGE $IMAGE '.spec.template.components[0].plugin.components = [{
      "name": "web-terminal-tooling",
      "container": {
        "image": $IMAGE
      }
    }]' \
  | kubectl apply -f -
```

![wto-bash-history-2](https://user-images.githubusercontent.com/16168279/163453639-6c0e8452-72d0-40db-9a99-99c1ed272356.gif)


