### PR TITLE
Install tar

### DIFF
--- a/build/template.Dockerfile
+++ b/build/template.Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir -p /home/user $INITIAL_CONFIG && \
     vi vim nano \
     # developer tools
 #@brew     mc \
-    curl git procps jq && \
+    curl tar git procps jq && \
     microdnf -y clean all
 
 ADD container-root-x86_64.tgz /


### PR DESCRIPTION
tar will be very helpful to have installed. While expectations what should be installed by default will vary widely by user, I think tar is a worthwhile addition:

* it is very small (<1MB) so doesn't increase image size much
* it allows to download (via curl) many pre-built binaries which are distributed as .tar.gz files

For example, adding tar allows users to:

* install Helm plugins like helm-diff (https://github.com/databus23/helm-diff)
* install Go binaries such as age (https://github.com/FiloSottile/age)

It would be very unfortunate if one has to create and configure a custom image to have something as essential as tar.