### PR TITLE
Build next images nightly in addition to on push

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -3,6 +3,8 @@ name: Next Container Build
 on:
   push:
     branches: [ main ]
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
 


### PR DESCRIPTION
### Description

To avoid stale images, make sure the web-terminal-tooling next image is built nightly in addition to on every push. This ensures the dependencies in the image are updated even if the repo is not being actively committed to.
