### PR TITLE
Add support for switching shell in terminal instances via wtoctl and add zsh to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN mkdir -p /home/user $INITIAL_CONFIG && \
     microdnf install -y --disablerepo=* --enablerepo=ubi-8-appstream-rpms --enablerepo=ubi-8-baseos-rpms \
     # bash completion tools
     bash-completion ncurses pkgconf-pkg-config findutils \
+    # zsh
+    zsh \
     # terminal-based editors
     vi vim nano \
     # developer tools
@@ -60,6 +62,7 @@ RUN for f in "${HOME}" "${INITIAL_CONFIG}" "/etc/passwd" "/etc/group"; do \
     rm -f /tmp/get-tooling-versions.sh
 
 USER 1001
+ENV SHELL /bin/bash
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 ENV SUMMARY="Web Terminal - Tooling container" \

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -10,7 +10,7 @@ fi
 # Add current (arbitrary) user to /etc/passwd and /etc/group
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
-    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:/bin/bash" >> /etc/passwd
+    echo "${USER_NAME:-user}:x:$(id -u):0:${USER_NAME:-user} user:${HOME}:${SHELL}" >> /etc/passwd
     echo "${USER_NAME:-user}:x:$(id -u):" >> /etc/group
   fi
 fi

--- a/etc/initial_config/.zshrc
+++ b/etc/initial_config/.zshrc
@@ -1,0 +1,56 @@
+# Set default editor to vim instead of default fallback vi
+export EDITOR=vim
+
+function help_message() {
+  echo "Installed tools:"
+  cat /tmp/installed_tools.txt
+  echo ""
+  echo "To customize this terminal, see 'wtoctl'"
+}
+
+alias help=help_message
+
+# Set up saving history and syncing between sessions
+setopt SHARE_HISTORY HIST_IGNORE_DUPS
+HISTFILE=~/.zsh_history
+HISTSIZE=1000
+SAVEHIST=1000
+setopt appendhistory
+bindkey -e
+
+zstyle :compinstall filename '/home/user/.zshrc'
+autoload -Uz compinit
+compinit
+
+# Source completions
+if command -v kubectl &>/dev/null; then
+  source <(kubectl completion zsh)
+fi
+if command -v oc &>/dev/null; then
+  source <(oc completion zsh)
+fi
+if command -v kn &>/dev/null; then
+  source <(kn completion zsh)
+fi
+if command -v helm &>/dev/null; then
+  source <(helm completion zsh 2>/dev/null) # Needed to avoid warning about kubeconfig being world-writable
+fi
+if command -v tkn &>/dev/null; then
+  source <(tkn completion zsh)
+fi
+if command -v virtctl &>/dev/null; then
+  source <(virtctl completion zsh)
+fi
+if command -v rhoas &>/dev/null; then
+  source <(rhoas completion zsh)
+fi
+if command -v subctl &>/dev/null; then
+  source <(subctl completion zsh)
+fi
+if command -v odo &>/dev/null; then
+  source <(odo completion zsh)
+fi
+
+PROMPT='%1N %~ %# '
+
+echo 'Welcome to the OpenShift Web Terminal. Type "help" for a list of installed CLI tools.'

--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -111,7 +111,11 @@ function set_timeout() {
   expect_one_arg "wtoctl set timeout" "$@"
   local TIMEOUT="$1"
   DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
-  UPDATED_JSON=$(echo "$DW_JSON" | jq --arg TIMEOUT "$TIMEOUT" "$JQ_SET_TIMEOUT_SCRIPT")
+  UPDATED_JSON=$(echo "$DW_JSON" | \
+    jq --arg COMPONENT "web-terminal-exec" \
+       --arg NAME "WEB_TERMINAL_IDLE_TIMEOUT" \
+       --arg VALUE "$TIMEOUT" \
+       "$JQ_SET_ENV_SCRIPT")
   echo "$UPDATED_JSON" | kubectl apply -f -
   echo "Updated Web Terminal idle timeout to $TIMEOUT. Terminal may restart."
 }
@@ -124,9 +128,56 @@ function reset_timeout() {
   fi
   expect_no_args "wtoctl reset timeout" "$@"
   DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
-  UPDATED_JSON=$(echo "$DW_JSON" | jq "$JQ_RESET_TIMEOUT_SCRIPT")
+  UPDATED_JSON=$(echo "$DW_JSON" | \
+    jq --arg COMPONENT "web-terminal-exec" \
+       --arg NAME "WEB_TERMINAL_IDLE_TIMEOUT" \
+       "$JQ_RESET_ENV_SCRIPT")
   echo "$UPDATED_JSON" | kubectl apply -f -
   echo "Reset Web Terminal idle timeout. Terminal may restart."
+}
+
+function get_shell() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Get shell used for terminal"
+    echo "Usage: 'wtoctl get shell'"
+    exit 0
+  fi
+  expect_no_args "wtoctl get shell" "$@"
+  echo "Current shell is $SHELL"
+}
+
+function set_shell() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Set shell used for terminal"
+    echo "Usage: 'wtoctl set shell <shell>'"
+    exit 0
+  fi
+  expect_one_arg "wtoctl set shell" "$@"
+  local SHELL="$1"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  UPDATED_JSON=$(echo "$DW_JSON" | \
+    jq --arg COMPONENT "web-terminal-tooling" \
+       --arg NAME "SHELL" \
+       --arg VALUE "$SHELL" \
+       "$JQ_SET_ENV_SCRIPT")
+  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "Updated Web Terminal shell to $SHELL. Terminal may restart."
+}
+
+function reset_shell() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Reset shell used for terminal to the default"
+    echo "Usage: 'wtoctl reset shell'"
+    exit 0
+  fi
+  expect_no_args "wtoctl reset shell" "$@"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  UPDATED_JSON=$(echo "$DW_JSON" | \
+    jq --arg COMPONENT "web-terminal-tooling" \
+       --arg NAME "SHELL" \
+       "$JQ_RESET_ENV_SCRIPT")
+  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "Reset Web Terminal shell. Terminal may restart"
 }
 
 function do_get() {
@@ -139,6 +190,8 @@ function do_get() {
     get_tooling_image "${@:2}" ;;
     "timeout")
     get_timeout "${@:2}" ;;
+    "shell")
+    get_shell "${@:2}" ;;
     "--help"|"help")
     get_help ;;
     *)
@@ -158,6 +211,8 @@ function do_set() {
     set_tooling_image "${@:2}" ;;
     "timeout")
     set_timeout "${@:2}" ;;
+    "shell")
+    set_shell "${@:2}" ;;
     "--help"|"help")
     set_help ;;
     *)
@@ -177,6 +232,8 @@ function do_reset() {
       reset_tooling_image "${@:2}" ;;
     "timeout")
       reset_timeout "${@:2}" ;;
+    "shell")
+      reset_shell "${@:2}" ;;
     "--help"|"help")
       reset_help ;;
     *)
@@ -202,6 +259,8 @@ case $1 in
     help_or_error image_help "wtoctl image" "${@:2}" ;;
   "timeout")
     help_or_error timeout_help "wtoctl timeout" "${@:2}" ;;
+  "shell")
+    help_or_error shell_help "wtoctl shell" "${@:2}" ;;
   *)
     echo "Unknown command $1 for wtoctl"
     echo "Run 'wtoctl --help' for usage"

--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -72,7 +72,7 @@ function set_tooling_image() {
   local IMAGE="$1"
   DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
   UPDATED_JSON=$(echo "$DW_JSON" | jq --arg IMAGE "$IMAGE" "$JQ_SET_IMAGE_SCRIPT")
-  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "$UPDATED_JSON" | oc apply -f -
   echo "Updated Web Terminal image to $IMAGE. Terminal may restart."
 }
 
@@ -85,7 +85,7 @@ function reset_tooling_image() {
   expect_no_args "wtoctl reset image" "$@"
   DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
   UPDATED_JSON=$(echo "$DW_JSON" | jq "$JQ_RESET_IMAGE_SCRIPT")
-  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "$UPDATED_JSON" | oc apply -f -
   echo "Reset Web Terminal tooling image. Terminal may restart"
 }
 
@@ -116,7 +116,7 @@ function set_timeout() {
        --arg NAME "WEB_TERMINAL_IDLE_TIMEOUT" \
        --arg VALUE "$TIMEOUT" \
        "$JQ_SET_ENV_SCRIPT")
-  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "$UPDATED_JSON" | oc apply -f -
   echo "Updated Web Terminal idle timeout to $TIMEOUT. Terminal may restart."
 }
 
@@ -132,7 +132,7 @@ function reset_timeout() {
     jq --arg COMPONENT "web-terminal-exec" \
        --arg NAME "WEB_TERMINAL_IDLE_TIMEOUT" \
        "$JQ_RESET_ENV_SCRIPT")
-  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "$UPDATED_JSON" | oc apply -f -
   echo "Reset Web Terminal idle timeout. Terminal may restart."
 }
 
@@ -160,7 +160,7 @@ function set_shell() {
        --arg NAME "SHELL" \
        --arg VALUE "$SHELL" \
        "$JQ_SET_ENV_SCRIPT")
-  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "$UPDATED_JSON" | oc apply -f -
   echo "Updated Web Terminal shell to $SHELL. Terminal may restart."
 }
 
@@ -176,7 +176,7 @@ function reset_shell() {
     jq --arg COMPONENT "web-terminal-tooling" \
        --arg NAME "SHELL" \
        "$JQ_RESET_ENV_SCRIPT")
-  echo "$UPDATED_JSON" | kubectl apply -f -
+  echo "$UPDATED_JSON" | oc apply -f -
   echo "Reset Web Terminal shell. Terminal may restart"
 }
 

--- a/etc/wtoctl_help.sh
+++ b/etc/wtoctl_help.sh
@@ -19,6 +19,7 @@ be used within a running terminal instance.
 Configurable fields:
   * image   - the image used for the Web Terminal
   * timeout - the time a Web Terminal may be idle before it is terminated
+  * shell   - the shell used for the Web Terminal (e.g. bash, zsh)
 
 Available commands:
   * get   - get the current value for a field
@@ -71,6 +72,19 @@ Examples:
 EOF
 }
 
+function shell_help() {
+  cat <<EOF
+The shell field defines the shell program used for the Web Terminal. By default,
+the /bin/bash is used. Currently, the shells bash (/bin/bash) and zsh (/bin/zsh)
+are available in the default Web Terminal image.
+
+If the selected shell is not present in the tooling image, the Web Terminal may
+fail to restart. If this occurs, the Web Terminal custom resource should be
+deleted by executing
+  oc delete devworkspace $DEVWORKSPACE_NAME --namespace $NAMESPACE
+EOF
+}
+
 function get_help() {
   cat <<EOF
 Gets the current value of a field.
@@ -78,6 +92,7 @@ Gets the current value of a field.
 Configurable fields:
   * image   - the image used for the Web Terminal
   * timeout - the time a Web Terminal may be idle before it is terminated
+  * shell   - the shell program used for the Web Terminal
 
 Usage:
   wtoctl get <field>
@@ -93,6 +108,7 @@ Sets a given field.
 Configurable fields:
   * image   - the image used for the Web Terminal
   * timeout - the duration a Web Terminal may be idle before it is terminated
+  * shell   - the shell program used for the Web Terminal
 
 Usage:
   wtoctl set <field> <value>
@@ -108,6 +124,7 @@ Resets a given field to its default value.
 Configurable fields:
   * image   - the image used for the terminal
   * timeout - the time a Web Terminal may be idle before it is terminated
+  * shell   - the shell program used for the Web Terminal
 
 Usage:
   wtoctl reset <field>


### PR DESCRIPTION
Add wtoctl commands `wtoctl [get|set|reset] shell [<SHELL>]` to allow configuring the shell used in Web Terminals, and add `zsh` to the default tooling image.

The `jq` scripts used in `wtoctl` are also updated to not erase user-set fields (e.g. don't delete env when resetting image/shell/timeout).

Closes issue https://issues.redhat.com/browse/WTO-166