### PR TITLE
Do basic validation on timeout duration format before applying

### DIFF
--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -110,6 +110,14 @@ function set_timeout() {
   fi
   expect_one_arg "wtoctl set timeout" "$@"
   local TIMEOUT="$1"
+
+  # Do some basic validation on timeout
+  duration_pattern='^-?([.0-9]+(h|m|s|ms))+$'
+  if ! [[ "$TIMEOUT" =~ $duration_pattern ]]; then
+    echo "Invalid timeout duration. See 'wtoctl timeout --help' for timeout format"
+    exit 1
+  fi
+
   DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
   UPDATED_JSON=$(echo "$DW_JSON" | \
     jq --arg COMPONENT "web-terminal-exec" \


### PR DESCRIPTION
Do basic validation that the timeout used with `wtoctl set timeout <duration>` matches the semantics of Go's [`ParseDuration`](https://pkg.go.dev/time#ParseDuration).

For now, we're just checking that the timeout is numbers followed by a duration suffix (h/m/s/ms) to match documentation on `wtoctl timeout help`. The regex also does allow for setting a negative timeout, which disables idling (and is not currently documented).

To test the image, execute `wtoctl set image quay.io/amisevsk/web-terminal-tooling:validation` on any cluster where WTO is installed.

This PR resolves https://issues.redhat.com/browse/WTO-177