### PR TITLE
Enable configuring persistent storage for terminals via wtoctl 

### DIFF
--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -28,7 +28,7 @@ if [[ $# -lt 1 ]]; then
 fi
 
 function preflight_checks() {
-  if [ -z $NAMESPACE ] || [ ! -f $DEVWORKSPACE_FLATTENED_DEVFILE ]; then
+  if [ -z "$NAMESPACE" ] || [ ! -f "$DEVWORKSPACE_FLATTENED_DEVFILE" ]; then
     echo "Container does not appear to be running in an OpenShift cluster -- wtoctl commands are unavailable"
     exit 1
   fi
@@ -228,10 +228,10 @@ function set_storage() {
 
   # Basic checks for storage parameters to avoid footguns
   if [ -e "$MOUNT_PATH" ]; then
-    echo "warning: Mount path $MOUNT_PATH already exists in this container. Mounting storage will overwrite contents of $MOUNT_PATH."
+    warning "Mount path $MOUNT_PATH already exists in this container. Mounting storage will overwrite contents of $MOUNT_PATH."
   fi
   if ! [[ "$STORAGE_SIZE" =~ ^[.0-9]+(K|Ki|M|Mi|G|Gi) ]]; then
-    echo "warning: Unrecognized Kubernetes unit suffix for storage: $STORAGE_SIZE"
+    warning "Unrecognized Kubernetes unit suffix for storage: $STORAGE_SIZE"
   fi
 
   read -rp "Adding persistent volume with size $STORAGE_SIZE to $MOUNT_PATH. Is this okay? (y/N): " OK
@@ -255,7 +255,7 @@ function reset_storage() {
   fi
   expect_no_args "wtoctl reset storage" "$@"
   local DELETE_PVC PVC_NAME
-  PVC_NAME=$(oc get pvc -o json | jq -r "$JQ_GET_PVC_NAME_SCRIPT")
+  PVC_NAME=$(oc get pvc -o json | jq -r --arg DEVWORKSPACE_NAME "$DEVWORKSPACE_NAME" "$JQ_GET_PVC_NAME_SCRIPT")
   read -rp "Would you like to also delete the persistent volume claim used for storage (name: $PVC_NAME)? (y/N): " DELETE_PVC
 
   DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)

--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -347,6 +347,8 @@ case $1 in
     help_or_error timeout_help "wtoctl timeout" "${@:2}" ;;
   "shell")
     help_or_error shell_help "wtoctl shell" "${@:2}" ;;
+  "storage")
+    help_or_error storage_help "wtoctl storage" "${@:2}" ;;
   *)
     echo "Unknown command $1 for wtoctl"
     echo "Run 'wtoctl --help' for usage"

--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -254,9 +254,18 @@ function reset_storage() {
     exit 0
   fi
   expect_no_args "wtoctl reset storage" "$@"
+  local DELETE_PVC PVC_NAME
+  PVC_NAME=$(oc get pvc -o json | jq -r "$JQ_GET_PVC_NAME_SCRIPT")
+  read -rp "Would you like to also delete the persistent volume claim used for storage (name: $PVC_NAME)? (y/N): " DELETE_PVC
+
   DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
   UPDATED_JSON=$(echo "$DW_JSON" | jq "$JQ_RESET_STORAGE_SCRIPT")
   echo "$UPDATED_JSON" | oc apply -f -
+  if [[ "$DELETE_PVC" =~ ^(y|Y|yes|Yes) ]] ; then
+    oc delete pvc -n "$NAMESPACE" "$PVC_NAME"
+    echo "Deleted persistent volume claim $PVC_NAME"
+  fi
+
   echo "Reset Web Terminal storage. Terminal may restart"
 }
 

--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -262,7 +262,7 @@ function reset_storage() {
   UPDATED_JSON=$(echo "$DW_JSON" | jq "$JQ_RESET_STORAGE_SCRIPT")
   echo "$UPDATED_JSON" | oc apply -f -
   if [[ "$DELETE_PVC" =~ ^(y|Y|yes|Yes) ]] ; then
-    oc delete pvc -n "$NAMESPACE" "$PVC_NAME"
+    oc delete pvc -n "$NAMESPACE" "$PVC_NAME" --wait=false
     echo "Deleted persistent volume claim $PVC_NAME"
   fi
 

--- a/etc/wtoctl
+++ b/etc/wtoctl
@@ -188,6 +188,78 @@ function reset_shell() {
   echo "Reset Web Terminal shell. Terminal may restart"
 }
 
+function get_storage() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Get persistent storage mounted to terminal"
+    echo "Usage: 'wtoctl get storage'"
+    exit 0
+  fi
+  expect_no_args "wtoctl get storage" "$@"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  STORAGE_SUMMARY=$(echo "$DW_JSON" | jq -r "$JQ_GET_STORAGE_SCRIPT")
+  echo "$STORAGE_SUMMARY"
+}
+
+function set_storage() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Add persistent storage to terminal"
+    echo "Usage: 'wtoctl set storage'"
+    exit 0
+  fi
+  expect_no_args "wtoctl set storage" "$@"
+  local STORAGE_SIZE MOUNT_PATH OK CURR_STORAGE_SIZE
+
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  CURR_STORAGE_SIZE=$(echo "$DW_JSON" | jq -r "$JQ_GET_STORAGE_SIZE_SCRIPT")
+
+  if [ -z "$CURR_STORAGE_SIZE" ]; then
+    read -rp "Enter desired storage size (default: '100Mi'): " STORAGE_SIZE
+  else
+    echo "Persistent storage is already configured. Using existing size '$CURR_STORAGE_SIZE'"
+    STORAGE_SIZE="$CURR_STORAGE_SIZE"
+  fi
+  read -rp "Enter desired mount path (default: '/home/user/storage'): " MOUNT_PATH
+  if [ -z "$STORAGE_SIZE" ]; then
+    STORAGE_SIZE="100Mi"
+  fi
+  if [ -z "$MOUNT_PATH" ]; then
+    MOUNT_PATH="/home/user/storage"
+  fi
+
+  # Basic checks for storage parameters to avoid footguns
+  if [ -e "$MOUNT_PATH" ]; then
+    echo "warning: Mount path $MOUNT_PATH already exists in this container. Mounting storage will overwrite contents of $MOUNT_PATH."
+  fi
+  if ! [[ "$STORAGE_SIZE" =~ ^[.0-9]+(K|Ki|M|Mi|G|Gi) ]]; then
+    echo "warning: Unrecognized Kubernetes unit suffix for storage: $STORAGE_SIZE"
+  fi
+
+  read -rp "Adding persistent volume with size $STORAGE_SIZE to $MOUNT_PATH. Is this okay? (y/N): " OK
+  if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
+    UPDATED_JSON=$(echo "$DW_JSON" | \
+      jq --arg VOLUME_SIZE "$STORAGE_SIZE" \
+         --arg MOUNT_PATH  "$MOUNT_PATH" \
+         "$JQ_SET_STORAGE_SCRIPT")
+    echo "$UPDATED_JSON" | oc apply -f -
+    echo "Updated Web Terminal storage. Terminal may restart"
+  else
+    echo "Not adding storage"
+  fi
+}
+
+function reset_storage() {
+  if [[ "$1" == "help" ]] || [[ "$1" == "--help" ]]; then
+    echo "Remove any mounted persistent storage from terminal"
+    echo "Usage: 'wtoctl reset storage'"
+    exit 0
+  fi
+  expect_no_args "wtoctl reset storage" "$@"
+  DW_JSON=$(oc get devworkspaces "$DEVWORKSPACE_NAME" -n "$NAMESPACE" -o json)
+  UPDATED_JSON=$(echo "$DW_JSON" | jq "$JQ_RESET_STORAGE_SCRIPT")
+  echo "$UPDATED_JSON" | oc apply -f -
+  echo "Reset Web Terminal storage. Terminal may restart"
+}
+
 function do_get() {
   if [[ $# -lt 1 ]]; then
     echo "wtoctl get expects additional arguments. See 'wtoctl get --help' for more information"
@@ -195,17 +267,19 @@ function do_get() {
   fi
   case $1 in
     "image")
-    get_tooling_image "${@:2}" ;;
+      get_tooling_image "${@:2}" ;;
     "timeout")
-    get_timeout "${@:2}" ;;
+      get_timeout "${@:2}" ;;
     "shell")
-    get_shell "${@:2}" ;;
+      get_shell "${@:2}" ;;
+    "storage")
+      get_storage "${@:2}" ;;
     "--help"|"help")
-    get_help ;;
+      get_help ;;
     *)
-    echo "Unknown option $1 for 'wtoctl get'"
-    echo "See 'wtoctl get --help' for usage."
-    exit 1
+      echo "Unknown option $1 for 'wtoctl get'"
+      echo "See 'wtoctl get --help' for usage."
+      exit 1
   esac
 }
 
@@ -216,17 +290,19 @@ function do_set() {
   fi
   case $1 in
     "image")
-    set_tooling_image "${@:2}" ;;
+      set_tooling_image "${@:2}" ;;
     "timeout")
-    set_timeout "${@:2}" ;;
+      set_timeout "${@:2}" ;;
     "shell")
-    set_shell "${@:2}" ;;
+      set_shell "${@:2}" ;;
+    "storage")
+      set_storage "${@:2}" ;;
     "--help"|"help")
-    set_help ;;
+      set_help ;;
     *)
-    echo "Unknown option $1 for 'wtoctl set'"
-    echo "See 'wtoctl set --help' for usage."
-    exit 1
+      echo "Unknown option $1 for 'wtoctl set'"
+      echo "See 'wtoctl set --help' for usage."
+      exit 1
   esac
 }
 
@@ -242,6 +318,8 @@ function do_reset() {
       reset_timeout "${@:2}" ;;
     "shell")
       reset_shell "${@:2}" ;;
+    "storage")
+      reset_storage "${@:2}" ;;
     "--help"|"help")
       reset_help ;;
     *)

--- a/etc/wtoctl_help.sh
+++ b/etc/wtoctl_help.sh
@@ -20,6 +20,7 @@ Configurable fields:
   * image   - the image used for the Web Terminal
   * timeout - the time a Web Terminal may be idle before it is terminated
   * shell   - the shell used for the Web Terminal (e.g. bash, zsh)
+  * storage - configure persistent storage to the Web Terminal
 
 Available commands:
   * get   - get the current value for a field
@@ -85,6 +86,23 @@ deleted by executing
 EOF
 }
 
+function storage_help() {
+  cat <<EOF
+This command allows for configuring persistent storage for the Web Terminal.
+Storage is added by mounting a persistent volume claim to this terminal,
+allowing for files to persist even if the terminal is shut down. When setting
+storage via 'wtoctl set storage', you will be prompted to specify the size of
+the volume required and the mount path within the terminal's container.
+
+Note that re-sizing persistent volume claims is currently not supported, so
+running the set command multiple times will not allow updating the volume size.
+
+If storage is misconfigured, the Web Terminal may fail to restart. If this
+occurs, the Web Terminal custom resource should be deleted by executing
+  oc delete devworkspace $DEVWORKSPACE_NAME --namespace $NAMESPACE
+EOF
+}
+
 function get_help() {
   cat <<EOF
 Gets the current value of a field.
@@ -93,6 +111,7 @@ Configurable fields:
   * image   - the image used for the Web Terminal
   * timeout - the time a Web Terminal may be idle before it is terminated
   * shell   - the shell program used for the Web Terminal
+  * storage - get current persistent storage configuration for the Web Terminal
 
 Usage:
   wtoctl get <field>
@@ -109,6 +128,7 @@ Configurable fields:
   * image   - the image used for the Web Terminal
   * timeout - the duration a Web Terminal may be idle before it is terminated
   * shell   - the shell program used for the Web Terminal
+  * storage - interactively configure storage for the current terminal
 
 Usage:
   wtoctl set <field> <value>
@@ -125,6 +145,7 @@ Configurable fields:
   * image   - the image used for the terminal
   * timeout - the time a Web Terminal may be idle before it is terminated
   * shell   - the shell program used for the Web Terminal
+  * storage - remove persistent storage from the Web Terminal
 
 Usage:
   wtoctl reset <field>

--- a/etc/wtoctl_help.sh
+++ b/etc/wtoctl_help.sh
@@ -11,6 +11,22 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
+# Check to see if we can output colors
+if [ -t 1 ]; then
+  colors=$(tput colors)
+  if [ -n "$colors" ] && [ "$colors" -ge 8 ]; then
+    ERR='\033[0;31m'
+    WARN='\033[1;33m'
+    NC='\033[0m'
+  fi
+fi
+function warning() {
+  echo -e "${WARN}warning: $1${NC}"
+}
+function error() {
+  echo -e "${ERR}error: $1${NC}"
+}
+
 function general_help() {
   cat <<EOF
 wtoctl is a simple tool for customizing Web Terminals in OpenShift intended to
@@ -157,7 +173,7 @@ EOF
 function expect_no_args() {
   CMD_REF="$1"; shift
   if [[ $# -gt 0 ]]; then
-    echo "Unknown option '$*' for '$CMD_REF'"
+    error "Unknown option '$*' for '$CMD_REF'"
     echo "See '$CMD_REF --help' for usage"
     exit 1
   fi
@@ -166,13 +182,14 @@ function expect_no_args() {
 function expect_one_arg() {
   CMD_REF="$1"; shift
   if [[ $# -eq 0 ]]; then
-    echo "Command '$CMD_REF' expects an argument"
+    error "Command '$CMD_REF' expects an argument"
     echo "See '$CMD_REF --help' for usage."
     exit 1
   fi
   if [[ $# -gt 1 ]]; then
-    echo "Command '$CMD_REF' expect only one argument"
+    error "Command '$CMD_REF' expect only one argument"
     echo "See '$CMD_REF --help' for usage."
+    exit 1
   fi
 }
 
@@ -184,7 +201,7 @@ function help_or_error() {
     "--help"|"help")
       $HELP_CMD ;;
     *)
-      echo "Unknown option '$1' for '$CMD_REF'"
+      error "Unknown option '$1' for '$CMD_REF'"
       echo "See '$CMD_REF --help' for usage"
       exit 1
   esac

--- a/etc/wtoctl_jq.sh
+++ b/etc/wtoctl_jq.sh
@@ -211,3 +211,10 @@ then
   del(.spec.template.attributes)
 else . end
 '
+
+# Get the name of the PVC that is used for this workspace's storage. Expects argument
+#   - $DEVWORKSPACE_NAME : name of the terminal's DevWorkspace
+export JQ_GET_PVC_NAME_SCRIPT='.items[]
+| select((.metadata.ownerReferences | length) > 0)
+| select(any(.metadata.ownerReferences[]; .controller == true and .kind == "DevWorkspace" and .name == $DEVWORKSPACE_NAME))
+| .metadata.name'


### PR DESCRIPTION
### Description
Add `storage` option to `wtoctl`:

* `wtoctl set storage` interactively prompts the user to configure a volume for their terminal (prompting for mount path and volume size)
* `wtoctl get storage` summarizes configured storage for the terminal, if present
* `wtoctl reset storage` removes the volume from the terminal and prompts the user to delete the terminal's PVC

In order to ensure we don't end up sharing a PVC, when storage is enabled, the workspace is configured for DWO's `per-workspace` storage type.

To test this PR, execute `wtoctl set image quay.io/amisevsk/web-terminal-tooling:storage` in any Web Terminal.

Resolves https://issues.redhat.com/browse/WTO-156

![wtoctl-storage](https://github.com/redhat-developer/web-terminal-tooling/assets/16168279/c142cd50-5798-4d2e-ae81-1fb610fabf40)
