### PR TITLE
Add wrapper to `kn` CLI to allow potentially downloading newer version from cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,9 @@ RUN for f in "${HOME}" "${INITIAL_CONFIG}" "${WRAPPER_BINARIES}" "${DOWNLOADED_B
     chmod -R g+rwX ${f}; \
     done && \
     /tmp/get-tooling-versions.sh > /tmp/installed_tools.txt && \
+    chmod g+rw /tmp/installed_tools.txt && \
     echo "Installed tools:" && \
-    cat /tmp/installed_tools.txt && \
-    rm -f /tmp/get-tooling-versions.sh
+    cat /tmp/installed_tools.txt
 
 USER 1001
 

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -28,6 +28,7 @@ readonly BINARIES_PATH="/home/user/bin"
 
 readonly PREF_USE_DOWNLOADED="use-downloaded"
 readonly PREF_USE_INSTALLED="use-installed"
+readonly PREF_CANNOT_DOWNLOAD="no-download"
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 readonly LOG_FILE="$SCRIPT_DIR/kn-wrapper.log"
@@ -65,7 +66,16 @@ function call_actual_kn() {
 }
 
 function get_download_url() {
-  URL=$(oc get consoleclidownloads kn -o json | jq -r '.spec.links[].href' | grep "$PLATFORM" | grep "$ARCH")
+  if ! oc auth can-i get consoleclidownloads --all-namespaces -q 2>>"$LOG_FILE"; then
+    error "Current user cannot get consoleclidownloads"
+    return 1
+  fi
+  CLI_DOWNLOAD_JSON=$(oc get consoleclidownloads kn -o json 2>>"$LOG_FILE")
+  if [ -z "$CLI_DOWNLOAD_JSON" ]; then
+    error "ConsoleCLIDownload 'kn' not found"
+    return 1
+  fi
+  URL=$(echo "$CLI_DOWNLOAD_JSON" | jq -r '.spec.links[].href' 2>>"$LOG_FILE"| grep "$PLATFORM" | grep "$ARCH")
   if [ -z "$URL" ]; then
     error "Could not get URL for 'kn' CLI"
     return 1
@@ -74,10 +84,14 @@ function get_download_url() {
   echo "$URL"
 }
 
-function download_kn() {
+function need_download() {
   if [ -x "$BINARIES_PATH/kn" ]; then
-    return
+    return 1
   fi
+  return 0
+}
+
+function download_kn() {
   URL="$1"
   mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH" >> "$LOG_FILE" 2>&1 || return 1
   info "Downloading kn from $URL"
@@ -93,6 +107,7 @@ function download_kn() {
 function prompt_user() {
   if ! KN_URL=$(get_download_url); then
     # Can't get URL to download kn so just use the default
+    save_preference "$PREF_CANNOT_DOWNLOAD"
     call_actual_kn
     exit 0
   fi
@@ -115,7 +130,22 @@ function prompt_user() {
 
 PREF=$(read_preferences)
 case "$PREF" in
-  "$PREF_USE_DOWNLOADED") download_kn; call_actual_kn ;;
+  "$PREF_USE_DOWNLOADED")
+    if need_download; then
+      if ! KN_URL=$(get_download_url); then
+        # Can't get URL to download kn so just use the default
+        save_preference "$PREF_CANNOT_DOWNLOAD"
+        call_actual_kn
+        exit 0
+      fi
+      if ! download_kn "$KN_URL"; then
+        error "Failed to re-download kn"
+        save_preference "$PREF_CANNOT_DOWNLOAD"
+      fi
+    fi
+    call_actual_kn
+    ;;
   "$PREF_USE_INSTALLED") call_actual_kn ;;
+  "$PREF_CANNOT_DOWNLOAD") call_actual_kn ;;
   *) prompt_user ;;
 esac

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -91,6 +91,7 @@ function call_actual_kn() {
   # Drop the script's directory from path to get the _other_ installed kn
   PATH=${PATH/${SCRIPT_DIR}:/}
   kn "${ORIGINAL_ARGS[@]}"
+  exit 0
 }
 
 # Log message with timestamp and error tag to the internal log file
@@ -183,28 +184,16 @@ function cache_download_url() {
   if [ -z "${KN_DOWNLOAD_URL+set}" ]; then
     # URL is still unset (i.e. this is the first call to this function). Try to read URL from cluster
     if ! KN_DOWNLOAD_URL=$(get_download_url); then
-      # Can't get URL to download kn; save this as preference to stop trying
-      save_preference "$PREF_CANNOT_DOWNLOAD"
+      # We can't get a download URL
       KN_DOWNLOAD_URL=""
     fi
   fi
-}
-
-# Returns 0 if 'kn' is already downloaded, and 1 otherwise
-function need_download() {
-  if [ -x "$BINARIES_PATH/kn" ]; then
-    return 1
-  fi
-  return 0
 }
 
 # Download and extract kn CLI from cluster. Downloaded CLI is saved to $BINARIES_PATH. Logs issues to $LOG_FILE and
 # returns 1 on error.
 function download_kn() {
   cache_download_url
-  if [ "$KN_DOWNLOAD_URL" == "" ]; then
-    return 1
-  fi
   mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH" >> "$LOG_FILE" 2>&1 || return 1
   info "Downloading kn from $KN_DOWNLOAD_URL"
   curl "$KN_DOWNLOAD_URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" >> "$LOG_FILE" 2>&1 || return 1
@@ -216,23 +205,12 @@ function download_kn() {
   info "Moved kn CLI to $BINARIES_PATH/kn"
 }
 
-# Check if kn is downloaded from the cluster and download it if not
-function ensure_downloaded() {
-  if need_download && ! download_kn; then
-    error "Failed to re-download binary"
-  fi
-}
-
 # Interactively prompt the user whether they want to download the 'kn' binary from the cluster before
 # continuing. If the user responds yes or no, this preference is saved for future use (if the user provides no
 # response, no download is performed and the preference is _not_ saved)
 function prompt_user() {
   cache_download_url
-  if [ "$KN_DOWNLOAD_URL" == "" ]; then
-    # Can't get URL to download kn so just use the default
-    call_actual_kn
-    exit 0
-  fi
+  info "Prompting user to download 'kn' from cluster"
   echo "Detected OpenShift Serverless installation in this cluster."
   echo "The 'kn' CLI is available at: $KN_DOWNLOAD_URL"
   read -rp "Would you like to automatically download 'kn' from this URL instead of using the built-in version? (y/N): " OK
@@ -243,9 +221,48 @@ function prompt_user() {
       echo "Failed to download CLI. See log file $LOG_FILE for details"
       exit 1
     fi
-    save_preference "$PREF_USE_DOWNLOADED"
+    PREF_SHOULD_DOWNLOAD="$VAL_USE_DOWNLOADED"
+    PREF_DOWNLOAD_URL="$KN_DOWNLOAD_URL"
+    save_preferences
   elif [[ "$OK" =~ ^(n|N|no|No) ]] ; then
-    save_preference "$PREF_USE_INSTALLED"
+    PREF_SHOULD_DOWNLOAD="$VAL_USE_INSTALLED"
+    save_preferences
+  fi
+}
+
+function handle_download_restore() {
+  info "Restoring cluster download for 'kn' binary"
+  cache_download_url
+  if [ -z "$KN_DOWNLOAD_URL" ]; then
+    info "Wrapper is configured to download 'kn' but cannot find URL"
+    echo "Warning: Web Terminal was previously configured to download 'kn' from the cluster, but is unable to complete the download."
+    echo "         Using built-in version -- see log file $LOG_FILE for more details."
+    echo ""
+    call_actual_kn
+  fi
+  if [ -n "$PREF_DOWNLOAD_URL" ] && [ "$KN_DOWNLOAD_URL" != "$PREF_DOWNLOAD_URL" ]; then
+    # We don't want to continue automatically downloading if the URL changes, to avoid unexpected results
+    info "Wrapper is configured to download 'kn' but URL has changed (new URL: $KN_DOWNLOAD_URL)"
+    echo "Warning: Web Terminal was previously configured to download 'kn' from the cluster, but the URL for downloading 'kn' has changed."
+    echo "  Previous URL: $PREF_DOWNLOAD_URL"
+    echo "  New URL:      $KN_DOWNLOAD_URL"
+    read -rp "Would you like to update the URL used to download 'kn'? (y/N): " OK
+    info "Received response $OK for update URL prompt"
+    if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
+      PREF_DOWNLOAD_URL="$KN_DOWNLOAD_URL"
+      save_preferences
+    else
+      # If user doesn't want to update the URL, then default to "use built-in version"
+      echo "Saving preference and using built-in version of 'kn'"
+      PREF_SHOULD_DOWNLOAD="$VAL_USE_INSTALLED"
+      save_preferences
+      call_actual_kn
+    fi
+  fi
+  if ! download_kn; then
+    echo "Failed to download 'kn' CLI. See log file $LOG_FILE for details."
+    PREF_SHOULD_DOWNLOAD="$VAL_CANNOT_DOWNLOAD"
+    save_preferences
   fi
 }
 
@@ -260,10 +277,26 @@ function check_wrapper_arguments() {
       exit 0
     ;;
     "$ARG_RESTORE_PREFERENCES")
-      PREF=$(read_preferences)
-      if [ "$PREF" == "$PREF_USE_DOWNLOADED" ]; then
-        info "Restoring preference $PREF in initial setup"
-        ensure_downloaded
+      if [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_USE_DOWNLOADED" ]; then
+        info "Restoring preference $PREF_SHOULD_DOWNLOAD in initial setup"
+        cache_download_url
+        if [ -z "$KN_DOWNLOAD_URL" ]; then
+          error "Could not detect URL for downloading kn from cluster"
+          exit 0
+        fi
+        if [ -z "$PREF_DOWNLOAD_URL" ]; then
+          error "Could not find URL to redownload 'kn'"
+          exit 0
+        fi
+        if [ "$PREF_DOWNLOAD_URL" != "$KN_DOWNLOAD_URL" ]; then
+          error "Detected URL $KN_DOWNLOAD_URL does not match previous URL $PREF_DOWNLOAD_URL"
+          exit 0
+        fi
+        if ! download_kn; then
+          error "Could not redownload 'kn' CLI"
+          exit 0
+        fi
+        info "Redownloaded kn CLI from $KN_DOWNLOAD_URL"
       fi
       exit 0
     ;;
@@ -278,22 +311,35 @@ function check_wrapper_arguments() {
   esac
 }
 
+read_preferences
+
+# Check if we're running non-interactively
 check_wrapper_arguments "$@"
 
-PREF=$(read_preferences)
-case "$PREF" in
-  "$PREF_USE_DOWNLOADED")
-    ensure_downloaded
+# Shortcut if the user answered "no" to the prompt earlier; we don't to make unnecessary
+# API calls on every invocation of 'kn' unless necessary
+if [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_CANNOT_DOWNLOAD" ] || [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_USE_INSTALLED" ]; then
+  call_actual_kn
+fi
+
+if [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_USE_DOWNLOADED" ]; then
+  # Shortcut if the user answered "yes" to the prompt and kn is already downloaded. Assume
+  # we don't need to do anything.
+  if [ -x "$BINARIES_PATH/kn" ]; then
     call_actual_kn
-    ;;
-  "$PREF_USE_INSTALLED")
-    call_actual_kn
-    ;;
-  "$PREF_CANNOT_DOWNLOAD")
-    call_actual_kn
-    ;;
-  *)
-    prompt_user
-    call_actual_kn
-    ;;
-esac
+  fi
+  # If 'kn' doesn't exist, attempt to download it
+  handle_download_restore
+  call_actual_kn
+fi
+
+# No preference set yet: we should prompt the user, if applicable
+cache_download_url
+if [ -n "$KN_DOWNLOAD_URL" ]; then
+  prompt_user
+else
+  PREF_SHOULD_DOWNLOAD="$VAL_CANNOT_DOWNLOAD"
+  save_preferences
+fi
+
+call_actual_kn

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -30,11 +30,21 @@ readonly PREF_USE_DOWNLOADED="use-downloaded"
 readonly PREF_USE_INSTALLED="use-installed"
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+readonly LOG_FILE="$SCRIPT_DIR/kn-wrapper.log"
+
 # Save original arguments in order to call 'kn' later seamlessly
 ORIGINAL_ARGS=( "$@" )
 
 function error() {
-  echo "error: $1" >&2
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "[$timestamp ERROR] $1" >> "$LOG_FILE"
+}
+
+function info() {
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo "[$timestamp INFO ] $1" >> "$LOG_FILE"
 }
 
 function save_preference() {
@@ -60,6 +70,7 @@ function get_download_url() {
     error "Could not get URL for 'kn' CLI"
     return 1
   fi
+  info "Found consoleclidownload for kn with URL $URL"
   echo "$URL"
 }
 
@@ -68,12 +79,15 @@ function download_kn() {
     return
   fi
   URL="$1"
-  mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH"
-  echo "Downloading kn from $URL"
-  curl "$URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz"
-  echo "Extracting kn CLI"
-  tar -xf "$KN_DOWNLOAD_PATH/kn.tar.gz" -C "$KN_DOWNLOAD_PATH"
-  mv "$KN_DOWNLOAD_PATH/kn" "$BINARIES_PATH/kn"
+  mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH" >> "$LOG_FILE" 2>&1 || return 1
+  info "Downloading kn from $URL"
+  curl "$URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" >> "$LOG_FILE" 2>&1 || return 1
+  info "Downloaded kn archive to $KN_DOWNLOAD_PATH/kn.tar.gz"
+  info "Extracting kn CLI to $KN_DOWNLOAD_PATH"
+  tar -xf "$KN_DOWNLOAD_PATH/kn.tar.gz" -C "$KN_DOWNLOAD_PATH" >> "$LOG_FILE" 2>&1 || return 1
+  info "Extracted kn CLI to $KN_DOWNLOAD_PATH"
+  mv "$KN_DOWNLOAD_PATH/kn" "$BINARIES_PATH/kn" || return 1
+  info "Moved kn CLI to $BINARIES_PATH/kn"
 }
 
 function prompt_user() {
@@ -86,8 +100,12 @@ function prompt_user() {
   echo "The 'kn' CLI is available at: $KN_URL"
   read -rp "Would you like to automatically download 'kn' from this URL instead of using the built-in version? (y/N): " OK
   echo ""
+  info "Received response '$OK' for prompt"
   if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
-    download_kn "$KN_URL"
+    if ! download_kn "$KN_URL"; then
+      echo "Failed to download CLI. See log file $LOG_FILE for details"
+      exit 1
+    fi
     save_preference "$PREF_USE_DOWNLOADED"
   elif [[ "$OK" =~ ^(n|N|no|No) ]] ; then
     save_preference "$PREF_USE_INSTALLED"

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -47,15 +47,15 @@ readonly KN_DOWNLOAD_PATH="/tmp/cli-downloads"
 readonly BINARIES_PATH="${DOWNLOADED_BINARIES:-/home/user/bin}"
 
 # Internal preferences and constants
-readonly PREF_USE_DOWNLOADED="use-downloaded"
-readonly PREF_USE_INSTALLED="use-installed"
-readonly PREF_CANNOT_DOWNLOAD="no-download"
-readonly DEVWORKSPACE_PREF_ANNOTATION="web-terminal.redhat.io/kn-wrapper-preference"
-readonly DEVWORKSPACE_PREF_ANNOTATION_ESCAPED="web-terminal\.redhat\.io/kn-wrapper-preference"
+readonly VAL_USE_DOWNLOADED="use-downloaded"
+readonly VAL_USE_INSTALLED="use-installed"
+readonly VAL_CANNOT_DOWNLOAD="no-download"
+readonly ANNOTATION_PREF_SHOULD_DOWNLOAD="web-terminal.redhat.io/kn-wrapper-should-download"
+readonly ANNOTATION_PREF_DOWNLOAD_URL="web-terminal.redhat.io/kn-wrapper-download-url"
 
 # Paths for storing logs and preferences
 readonly LOG_FILE="$SCRIPT_DIR/kn-wrapper.log"
-readonly PREFS_FILE="$SCRIPT_DIR/kn-wrapper-preferences"
+readonly PREFS_FILE="$SCRIPT_DIR/kn-wrapper.preferences"
 
 # Wrapper-specific arguments, prefixed by 'wto' to avoid colliding with any arguments
 # in the wrapped binary
@@ -63,6 +63,12 @@ readonly ARG_RESET_WRAPPER="--wto-reset-preferences"
 readonly ARG_RESTORE_PREFERENCES="--wto-restore-preferences"
 readonly ARG_PRINT_LOG="--wto-show-logs"
 
+# Env vars for preferences. These should be loaded from the $PREFS_FILE if it exists, or read from
+# the DevWorkspace annotations if not.
+declare PREF_SHOULD_DOWNLOAD
+declare PREF_DOWNLOAD_URL
+
+# Cached download URL to avoid making multiple API calls
 declare KN_DOWNLOAD_URL
 
 # Save original arguments in order to call 'kn' seamlessly later
@@ -91,43 +97,47 @@ function call_actual_kn() {
 function error() {
   local timestamp
   timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo "[$timestamp ERROR] $1" >> "$LOG_FILE"
+  echo -e "[$timestamp ERROR] $1" >> "$LOG_FILE"
 }
 
 # Log message with timestamp and info tag to the internal log file
 function info() {
   local timestamp
   timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-  echo "[$timestamp INFO ] $1" >> "$LOG_FILE"
+  echo -e "[$timestamp INFO ] $1" >> "$LOG_FILE"
 }
 
-# Save user preference (download or don't) to file and DevWorkspace annotation
-function save_preference() {
-  local PREF="$1"
-  info "Saving preference $PREF"
-  echo "$PREF" > "$PREFS_FILE"
-  info "Adding annotation to DevWorkspace to save download preference"
-  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" "$DEVWORKSPACE_PREF_ANNOTATION=$PREF" >>"$LOG_FILE" 2>&1
+# Save user preferences to file and DevWorkspace annotations
+function save_preferences() {
+  echo PREF_SHOULD_DOWNLOAD="${PREF_SHOULD_DOWNLOAD}" > "$PREFS_FILE"
+  echo PREF_DOWNLOAD_URL="${PREF_DOWNLOAD_URL}" >> "$PREFS_FILE"
+  info "Saved preferences:\n$(sed 's|^|    |' "$PREFS_FILE")"
+  info "Adding annotations to DevWorkspace to save preferences between restarts"
+  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" --overwrite \
+    "${ANNOTATION_PREF_SHOULD_DOWNLOAD}=${PREF_SHOULD_DOWNLOAD}" \
+    "${ANNOTATION_PREF_DOWNLOAD_URL}=${PREF_DOWNLOAD_URL}" \
+    >>"$LOG_FILE" 2>&1
 }
 
-# Read preferences. If preference file exists, read from there; otherwise, read from DevWorkspace annotations on cluster
+# Read preferences. If preference file exists, set preferences from file; otherwise, read from DevWorkspace annotations on cluster
 # If preference is read from DevWorkspace, save this preference to the preference file to speed up future calls.
-# This function prints the detected preference, if any.
 function read_preferences() {
   if [ -f "$PREFS_FILE" ]; then
-    cat "$PREFS_FILE"
+    # shellcheck source=/dev/null
+    source "${PREFS_FILE}"
     return
   fi
   info "No preference file found, attempting to read preference from DevWorkspace annotations"
-  ANNOTATION_PREF=$(oc get dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" -o jsonpath="{.metadata.annotations.$DEVWORKSPACE_PREF_ANNOTATION_ESCAPED}" 2>>"$LOG_FILE")
-  if [ -n "$ANNOTATION_PREF" ]; then
-    # Save preference from workspace to file to avoid having to make API calls all the time
-    info "Read preference $ANNOTATION_PREF from DevWorkspace"
-    echo "$ANNOTATION_PREF" > "$PREFS_FILE"
-    echo "$ANNOTATION_PREF"
-  else
-    info "Could not find preference in DevWorkspace annotations"
-  fi
+
+  local dw_json
+  dw_json=$(oc get dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" -o json 2>>"$LOG_FILE")
+  PREF_SHOULD_DOWNLOAD=$(echo "$dw_json" | jq -r --arg ANNOT "$ANNOTATION_PREF_SHOULD_DOWNLOAD" '.metadata.annotations[$ANNOT] // ""')
+  PREF_DOWNLOAD_URL=$(echo "$dw_json" | jq -r --arg ANNOT "$ANNOTATION_PREF_DOWNLOAD_URL" '.metadata.annotations[$ANNOT] // ""')
+
+  # Save results to file to avoid API calls later
+  echo PREF_SHOULD_DOWNLOAD="${PREF_SHOULD_DOWNLOAD}" > "$PREFS_FILE"
+  echo PREF_DOWNLOAD_URL="${PREF_DOWNLOAD_URL}" >> "$PREFS_FILE"
+  info "Read preferences from DevWorkspace:\n$(sed 's|^|    |' "$PREFS_FILE")"
 }
 
 # Reset any saved preferences (both in the preferences file and DevWorkspace annotations) and remove downloaded 'kn'
@@ -136,7 +146,10 @@ function reset_wrapper() {
   info "Resetting kn download preference and removing downloaded binary"
   rm -rf "$PREFS_FILE"
   rm -rf "$BINARIES_PATH/kn"
-  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" "${DEVWORKSPACE_PREF_ANNOTATION}-" >>"$LOG_FILE" 2>&1
+  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" \
+    "${ANNOTATION_PREF_SHOULD_DOWNLOAD}-" \
+    "${ANNOTATION_PREF_DOWNLOAD_URL}-" \
+    >>"$LOG_FILE" 2>&1
 }
 
 # Try to read download URL from ConsoleCLIDownloads custom resources on the cluster. If we cannot get a URL for kn,

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -36,6 +36,12 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 readonly LOG_FILE="$SCRIPT_DIR/kn-wrapper.log"
 readonly PREFS_FILE="$SCRIPT_DIR/kn-wrapper-preferences"
 
+# Wrapper-specific arguments, prefixed by 'wto' to avoid colliding with any arguments
+# in the wrapped binary
+readonly ARG_RESET_WRAPPER="--wto-reset-preferences"
+readonly ARG_RESTORE_PREFERENCES="--wto-restore-preferences"
+readonly ARG_PRINT_LOG="--wto-show-logs"
+
 # Save original arguments in order to call 'kn' later seamlessly
 ORIGINAL_ARGS=( "$@" )
 
@@ -73,6 +79,12 @@ function read_preferences() {
   else
     info "Could not find preference in DevWorkspace annotations"
   fi
+}
+
+function reset_wrapper() {
+  info "Resetting kn download preference and removing downloaded binary"
+  rm -rf "$PREFS_FILE"
+  rm -rf "$BINARIES_PATH/kn"
 }
 
 function call_actual_kn() {
@@ -143,6 +155,45 @@ function prompt_user() {
   fi
   call_actual_kn
 }
+
+function check_wrapper_arguments() {
+  if [[ $# != 1 ]]; then
+    return
+  fi
+  case "$1" in
+    "$ARG_RESET_WRAPPER")
+  reset_wrapper
+  exit 0
+    ;;
+    "$ARG_RESTORE_PREFERENCES")
+      PREF=$(read_preferences)
+      if [ "$PREF" == "$PREF_USE_DOWNLOADED" ]; then
+  info "Restoring preference $PREF in initial setup"
+  if need_download; then
+    if ! KN_URL=$(get_download_url); then
+      # Can't get URL to download kn so just use the default
+      save_preference "$PREF_CANNOT_DOWNLOAD"
+      exit 0
+    fi
+    if ! download_kn "$KN_URL"; then
+      error "Failed to re-download kn"
+      save_preference "$PREF_CANNOT_DOWNLOAD"
+    fi
+  fi
+      fi
+      exit 0
+    ;;
+    "$ARG_PRINT_LOG")
+      cat "$LOG_FILE"
+  exit 0
+    ;;
+    --wto-*)
+      echo "Invalid wrapper argument $1"
+      exit 1
+  esac
+}
+
+check_wrapper_arguments "$@"
 
 PREF=$(read_preferences)
 case "$PREF" in

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -324,8 +324,9 @@ read_preferences
 
 # Check wrapper-specific arguments and handle them without running kn
 check_wrapper_arguments "$@"
-# Check if we're running interactively (if we have a stdin)
-if [ ! -t 0 ]; then
+# Check if we're running interactively (if we have a stdin) and if output is to stdout (or a pipe)
+# If we're in either case (non-interactive or piped) don't prompt and just call whatever kn we've got.
+if [ ! -t 0 ] || [ ! -t 1 ]; then
   call_actual_kn
 fi
 

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Copyright (c) 2020-2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+#
+# This script is meant to serve as a wrapper for the `kn` CLI in order to 
+# facilitate downloading and updated version of the CLI from the cluster. 
+# It is meant to be placed in $PATH earlier than the actual `kn` CLI in order
+# to prompt the user to download `kn` instead of using the installed version.
+#
+
+set -e
+
+readonly PLATFORM="linux"
+readonly ARCH="amd64"
+
+readonly KN_DOWNLOAD_PATH="/tmp/cli-downloads"
+readonly BINARIES_PATH="/home/user/bin"
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+
+# Save original arguments in order to call 'kn' later seamlessly
+ORIGINAL_ARGS=( "$@" )
+
+function error() {
+  echo "error: $1" >&2
+}
+
+function call_actual_kn() {
+  # Drop the script's directory from path to get the other installed kn
+  PATH=${PATH/${SCRIPT_DIR}:/}
+  kn "${ORIGINAL_ARGS[@]}"
+}
+
+function clean_up_wrapper_script() {
+  THIS_SCRIPT="${SCRIPT_DIR:?}/$(basename "$0")"
+  rm -rf "$THIS_SCRIPT"
+}
+
+function get_download_url() {
+  URL=$(oc get consoleclidownloads kn -o json | jq -r '.spec.links[].href' | grep "$PLATFORM" | grep "$ARCH")
+  if [ -z "$URL" ]; then
+    error "Could not get URL for 'kn' CLI"
+    return 1
+  fi
+  echo "$URL"
+}
+
+function download_kn() {
+  URL="$1"
+  mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH"
+  echo "Downloading kn from $URL"
+  curl "$URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" 
+  echo "Extracting kn CLI"
+  tar -xf "$KN_DOWNLOAD_PATH/kn.tar.gz" -C "$KN_DOWNLOAD_PATH"
+  mv "$KN_DOWNLOAD_PATH/kn" "$BINARIES_PATH/"
+}
+
+function prompt_user() {
+  if ! KN_URL=$(get_download_url); then
+    # Can't get URL to download kn so just use the default
+    call_actual_kn
+    exit 0
+  fi
+  echo "Detected serverless installation in this cluster."
+  echo "The 'kn' CLI is available at: $KN_URL"
+  read -rp "Would you like to automatically download 'kn' from this URL instead of using the built-in version? (y/N): " OK
+  echo ""
+  if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
+    download_kn "$KN_URL"
+    clean_up_wrapper_script
+  elif [[ "$OK" =~ ^(n|N|no|No) ]] ; then
+    clean_up_wrapper_script
+  fi
+  call_actual_kn
+}
+
+prompt_user

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -44,7 +44,7 @@ readonly ARCH="amd64"
 
 # Directories used in wrapper
 readonly KN_DOWNLOAD_PATH="/tmp/cli-downloads"
-readonly BINARIES_PATH="/home/user/bin"
+readonly BINARIES_PATH="${DOWNLOADED_BINARIES:-/home/user/bin}"
 
 # Internal preferences and constants
 readonly PREF_USE_DOWNLOADED="use-downloaded"

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -16,23 +16,44 @@
 # facilitate downloading and updated version of the CLI from the cluster.
 # It is meant to be placed in $PATH earlier than the actual `kn` CLI in order
 # to prompt the user to download `kn` instead of using the installed version.
+# The user's decision is saved, so they are only prompted once; subsequent calls
+# to this wrapper script will transparently call 'kn' (downloaded or default)
+# with all provided arguments
+#
+# This wrapper does not output to stdout/stderr to avoid cluttering the terminal
+# (except when prompting the user to download the binary from the cluster). All
+# output is redirected to a log file named `kn-wrapper.log` in the script's
+# directory
+#
+# This wrapper script takes two wrapper-specific arguments to facilitate easier
+# setup:
+#   --wto-reset-preferences   - Reset any saved preferences and remove existing
+#                               downloaded 'kn' binary, if it exists.
+#   --wto-restore-preferences - Non-interactively read preferences and download
+#                               'kn' from the cluster if necessary. This is used
+#                               for initial setup when the Web Terminal starts.
+#   --wto-show-logs           - Print internal log file to standard out
 #
 
 set -e
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+
 readonly PLATFORM="linux"
 readonly ARCH="amd64"
 
+# Directories used in wrapper
 readonly KN_DOWNLOAD_PATH="/tmp/cli-downloads"
 readonly BINARIES_PATH="/home/user/bin"
 
+# Internal preferences and constants
 readonly PREF_USE_DOWNLOADED="use-downloaded"
 readonly PREF_USE_INSTALLED="use-installed"
 readonly PREF_CANNOT_DOWNLOAD="no-download"
 readonly DEVWORKSPACE_PREF_ANNOTATION="web-terminal.redhat.io/kn-wrapper-preference"
 readonly DEVWORKSPACE_PREF_ANNOTATION_ESCAPED="web-terminal\.redhat\.io/kn-wrapper-preference"
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+# Paths for storing logs and preferences
 readonly LOG_FILE="$SCRIPT_DIR/kn-wrapper.log"
 readonly PREFS_FILE="$SCRIPT_DIR/kn-wrapper-preferences"
 
@@ -42,28 +63,56 @@ readonly ARG_RESET_WRAPPER="--wto-reset-preferences"
 readonly ARG_RESTORE_PREFERENCES="--wto-restore-preferences"
 readonly ARG_PRINT_LOG="--wto-show-logs"
 
-# Save original arguments in order to call 'kn' later seamlessly
+declare KN_DOWNLOAD_URL
+
+# Save original arguments in order to call 'kn' seamlessly later
 ORIGINAL_ARGS=( "$@" )
 
+function internal_args_help() {
+  cat <<EOF
+Supported internal arguments:
+  --wto-reset-preferences   - Reset any saved preferences and remove existing
+                              downloaded 'kn' binary, if it exists.
+  --wto-restore-preferences - Non-interactively read preferences and download
+                              'kn' from the cluster if necessary. This is used
+                              for initial setup when the Web Terminal starts.
+  --wto-show-logs           - Print internal log file to standard out
+EOF
+}
+
+# Call the wrapped 'kn' binary using the originally-provided arguments
+function call_actual_kn() {
+  # Drop the script's directory from path to get the _other_ installed kn
+  PATH=${PATH/${SCRIPT_DIR}:/}
+  kn "${ORIGINAL_ARGS[@]}"
+}
+
+# Log message with timestamp and error tag to the internal log file
 function error() {
   local timestamp
   timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo "[$timestamp ERROR] $1" >> "$LOG_FILE"
 }
 
+# Log message with timestamp and info tag to the internal log file
 function info() {
   local timestamp
   timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   echo "[$timestamp INFO ] $1" >> "$LOG_FILE"
 }
 
+# Save user preference (download or don't) to file and DevWorkspace annotation
 function save_preference() {
   local PREF="$1"
+  info "Saving preference $PREF"
   echo "$PREF" > "$PREFS_FILE"
   info "Adding annotation to DevWorkspace to save download preference"
   oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" "$DEVWORKSPACE_PREF_ANNOTATION=$PREF" >>"$LOG_FILE" 2>&1
 }
 
+# Read preferences. If preference file exists, read from there; otherwise, read from DevWorkspace annotations on cluster
+# If preference is read from DevWorkspace, save this preference to the preference file to speed up future calls.
+# This function prints the detected preference, if any.
 function read_preferences() {
   if [ -f "$PREFS_FILE" ]; then
     cat "$PREFS_FILE"
@@ -81,18 +130,18 @@ function read_preferences() {
   fi
 }
 
+# Reset any saved preferences (both in the preferences file and DevWorkspace annotations) and remove downloaded 'kn'
+# binary, if present
 function reset_wrapper() {
   info "Resetting kn download preference and removing downloaded binary"
   rm -rf "$PREFS_FILE"
   rm -rf "$BINARIES_PATH/kn"
+  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" "${DEVWORKSPACE_PREF_ANNOTATION}-" >>"$LOG_FILE" 2>&1
 }
 
-function call_actual_kn() {
-  # Drop the script's directory from path to get the other installed kn
-  PATH=${PATH/${SCRIPT_DIR}:/}
-  kn "${ORIGINAL_ARGS[@]}"
-}
-
+# Try to read download URL from ConsoleCLIDownloads custom resources on the cluster. If we cannot get a URL for kn,
+# returns status code 1; otherwise, prints the URL. This function is relatively slow due to the API calls; function
+# cache_download_url() should be used instead in most cases.
 function get_download_url() {
   if ! oc auth can-i get consoleclidownloads --all-namespaces -q 2>>"$LOG_FILE"; then
     error "Current user cannot get consoleclidownloads"
@@ -112,6 +161,23 @@ function get_download_url() {
   echo "$URL"
 }
 
+# Lazy-load the download URL for the kn binary. If we haven't already loaded it, attempt to read the URL from the cluster
+# via get_download_url(). After calling this function $KN_DOWNLOAD_URL stores the URL for downloading, or is empty if
+# kn cannot be downloaded
+function cache_download_url() {
+  # We have to be careful here; the URL can either be an actual URL or empty if e.g. kn is not available on the cluster
+  # Variable expansion '${VAR+set}' will be empty only if the variable is unset or null
+  if [ -z "${KN_DOWNLOAD_URL+set}" ]; then
+    # URL is still unset (i.e. this is the first call to this function). Try to read URL from cluster
+    if ! KN_DOWNLOAD_URL=$(get_download_url); then
+      # Can't get URL to download kn; save this as preference to stop trying
+      save_preference "$PREF_CANNOT_DOWNLOAD"
+      KN_DOWNLOAD_URL=""
+    fi
+  fi
+}
+
+# Returns 0 if 'kn' is already downloaded, and 1 otherwise
 function need_download() {
   if [ -x "$BINARIES_PATH/kn" ]; then
     return 1
@@ -119,11 +185,16 @@ function need_download() {
   return 0
 }
 
+# Download and extract kn CLI from cluster. Downloaded CLI is saved to $BINARIES_PATH. Logs issues to $LOG_FILE and
+# returns 1 on error.
 function download_kn() {
-  URL="$1"
+  cache_download_url
+  if [ "$KN_DOWNLOAD_URL" == "" ]; then
+    return 1
+  fi
   mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH" >> "$LOG_FILE" 2>&1 || return 1
-  info "Downloading kn from $URL"
-  curl "$URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" >> "$LOG_FILE" 2>&1 || return 1
+  info "Downloading kn from $KN_DOWNLOAD_URL"
+  curl "$KN_DOWNLOAD_URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" >> "$LOG_FILE" 2>&1 || return 1
   info "Downloaded kn archive to $KN_DOWNLOAD_PATH/kn.tar.gz"
   info "Extracting kn CLI to $KN_DOWNLOAD_PATH"
   tar -xf "$KN_DOWNLOAD_PATH/kn.tar.gz" -C "$KN_DOWNLOAD_PATH" >> "$LOG_FILE" 2>&1 || return 1
@@ -132,20 +203,30 @@ function download_kn() {
   info "Moved kn CLI to $BINARIES_PATH/kn"
 }
 
+# Check if kn is downloaded from the cluster and download it if not
+function ensure_downloaded() {
+  if need_download && ! download_kn; then
+    error "Failed to re-download binary"
+  fi
+}
+
+# Interactively prompt the user whether they want to download the 'kn' binary from the cluster before
+# continuing. If the user responds yes or no, this preference is saved for future use (if the user provides no
+# response, no download is performed and the preference is _not_ saved)
 function prompt_user() {
-  if ! KN_URL=$(get_download_url); then
+  cache_download_url
+  if [ "$KN_DOWNLOAD_URL" == "" ]; then
     # Can't get URL to download kn so just use the default
-    save_preference "$PREF_CANNOT_DOWNLOAD"
     call_actual_kn
     exit 0
   fi
-  echo "Detected serverless installation in this cluster."
-  echo "The 'kn' CLI is available at: $KN_URL"
+  echo "Detected OpenShift Serverless installation in this cluster."
+  echo "The 'kn' CLI is available at: $KN_DOWNLOAD_URL"
   read -rp "Would you like to automatically download 'kn' from this URL instead of using the built-in version? (y/N): " OK
   echo ""
   info "Received response '$OK' for prompt"
   if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
-    if ! download_kn "$KN_URL"; then
+    if ! download_kn; then
       echo "Failed to download CLI. See log file $LOG_FILE for details"
       exit 1
     fi
@@ -153,42 +234,33 @@ function prompt_user() {
   elif [[ "$OK" =~ ^(n|N|no|No) ]] ; then
     save_preference "$PREF_USE_INSTALLED"
   fi
-  call_actual_kn
 }
 
+# Check arguments specific to this wrapper script; these are useful for debugging and initial setup.
 function check_wrapper_arguments() {
   if [[ $# != 1 ]]; then
     return
   fi
   case "$1" in
     "$ARG_RESET_WRAPPER")
-  reset_wrapper
-  exit 0
+      reset_wrapper
+      exit 0
     ;;
     "$ARG_RESTORE_PREFERENCES")
       PREF=$(read_preferences)
       if [ "$PREF" == "$PREF_USE_DOWNLOADED" ]; then
-  info "Restoring preference $PREF in initial setup"
-  if need_download; then
-    if ! KN_URL=$(get_download_url); then
-      # Can't get URL to download kn so just use the default
-      save_preference "$PREF_CANNOT_DOWNLOAD"
-      exit 0
-    fi
-    if ! download_kn "$KN_URL"; then
-      error "Failed to re-download kn"
-      save_preference "$PREF_CANNOT_DOWNLOAD"
-    fi
-  fi
+        info "Restoring preference $PREF in initial setup"
+        ensure_downloaded
       fi
       exit 0
     ;;
     "$ARG_PRINT_LOG")
       cat "$LOG_FILE"
-  exit 0
+      exit 0
     ;;
     --wto-*)
       echo "Invalid wrapper argument $1"
+      internal_args_help
       exit 1
   esac
 }
@@ -198,21 +270,17 @@ check_wrapper_arguments "$@"
 PREF=$(read_preferences)
 case "$PREF" in
   "$PREF_USE_DOWNLOADED")
-    if need_download; then
-      if ! KN_URL=$(get_download_url); then
-        # Can't get URL to download kn so just use the default
-        save_preference "$PREF_CANNOT_DOWNLOAD"
-        call_actual_kn
-        exit 0
-      fi
-      if ! download_kn "$KN_URL"; then
-        error "Failed to re-download kn"
-        save_preference "$PREF_CANNOT_DOWNLOAD"
-      fi
-    fi
+    ensure_downloaded
     call_actual_kn
     ;;
-  "$PREF_USE_INSTALLED") call_actual_kn ;;
-  "$PREF_CANNOT_DOWNLOAD") call_actual_kn ;;
-  *) prompt_user ;;
+  "$PREF_USE_INSTALLED")
+    call_actual_kn
+    ;;
+  "$PREF_CANNOT_DOWNLOAD")
+    call_actual_kn
+    ;;
+  *)
+    prompt_user
+    call_actual_kn
+    ;;
 esac

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -111,6 +111,12 @@ function info() {
   echo -e "[$timestamp INFO ] $1" >> "$LOG_FILE"
 }
 
+# Print a message to the user (error or informational). Message is printed to
+# stderr
+function message() {
+  echo "$@" >&2
+}
+
 # Save user preferences to file and DevWorkspace annotations
 function save_preferences() {
   echo PREF_SHOULD_DOWNLOAD="${PREF_SHOULD_DOWNLOAD}" > "$PREFS_FILE"
@@ -214,14 +220,14 @@ function download_kn() {
 function prompt_user() {
   cache_download_url
   info "Prompting user to download 'kn' from cluster"
-  echo "Detected OpenShift Serverless installation in this cluster."
-  echo "The 'kn' CLI is available at: $KN_DOWNLOAD_URL"
+  message "Detected OpenShift Serverless installation in this cluster."
+  message "The 'kn' CLI is available at: $KN_DOWNLOAD_URL"
   read -rp "Would you like to automatically download 'kn' from this URL instead of using the built-in version? (y/N): " OK
-  echo ""
+  message ""
   info "Received response '$OK' for prompt"
   if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
     if ! download_kn; then
-      echo "Failed to download CLI. See log file $LOG_FILE for details"
+      message "Failed to download CLI. See log file $LOG_FILE for details"
       exit 1
     fi
     PREF_SHOULD_DOWNLOAD="$VAL_USE_DOWNLOADED"
@@ -238,17 +244,17 @@ function handle_download_restore() {
   cache_download_url
   if [ -z "$KN_DOWNLOAD_URL" ]; then
     info "Wrapper is configured to download 'kn' but cannot find URL"
-    echo "Warning: Web Terminal was previously configured to download 'kn' from the cluster, but is unable to complete the download."
-    echo "         Using built-in version -- see log file $LOG_FILE for more details."
-    echo ""
+    message "Warning: Web Terminal was previously configured to download 'kn' from the cluster, but is unable to complete the download."
+    message "         Using built-in version -- see log file $LOG_FILE for more details."
+    message ""
     call_actual_kn
   fi
   if [ -n "$PREF_DOWNLOAD_URL" ] && [ "$KN_DOWNLOAD_URL" != "$PREF_DOWNLOAD_URL" ]; then
     # We don't want to continue automatically downloading if the URL changes, to avoid unexpected results
     info "Wrapper is configured to download 'kn' but URL has changed (new URL: $KN_DOWNLOAD_URL)"
-    echo "Warning: Web Terminal was previously configured to download 'kn' from the cluster, but the URL for downloading 'kn' has changed."
-    echo "  Previous URL: $PREF_DOWNLOAD_URL"
-    echo "  New URL:      $KN_DOWNLOAD_URL"
+    message "Warning: Web Terminal was previously configured to download 'kn' from the cluster, but the URL for downloading 'kn' has changed."
+    message "  Previous URL: $PREF_DOWNLOAD_URL"
+    message "  New URL:      $KN_DOWNLOAD_URL"
     read -rp "Would you like to update the URL used to download 'kn'? (y/N): " OK
     info "Received response $OK for update URL prompt"
     if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
@@ -256,14 +262,14 @@ function handle_download_restore() {
       save_preferences
     else
       # If user doesn't want to update the URL, then default to "use built-in version"
-      echo "Saving preference and using built-in version of 'kn'"
+      message "Saving preference and using built-in version of 'kn'"
       PREF_SHOULD_DOWNLOAD="$VAL_USE_INSTALLED"
       save_preferences
       call_actual_kn
     fi
   fi
   if ! download_kn; then
-    echo "Failed to download 'kn' CLI. See log file $LOG_FILE for details."
+    message "Failed to download 'kn' CLI. See log file $LOG_FILE for details."
     PREF_SHOULD_DOWNLOAD="$VAL_CANNOT_DOWNLOAD"
     save_preferences
   fi
@@ -308,7 +314,7 @@ function check_wrapper_arguments() {
       exit 0
     ;;
     --wto-*)
-      echo "Invalid wrapper argument $1"
+      message "Invalid wrapper argument $1"
       internal_args_help
       exit 1
   esac

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -12,8 +12,8 @@
 #
 
 #
-# This script is meant to serve as a wrapper for the `kn` CLI in order to 
-# facilitate downloading and updated version of the CLI from the cluster. 
+# This script is meant to serve as a wrapper for the `kn` CLI in order to
+# facilitate downloading and updated version of the CLI from the cluster.
 # It is meant to be placed in $PATH earlier than the actual `kn` CLI in order
 # to prompt the user to download `kn` instead of using the installed version.
 #
@@ -26,8 +26,10 @@ readonly ARCH="amd64"
 readonly KN_DOWNLOAD_PATH="/tmp/cli-downloads"
 readonly BINARIES_PATH="/home/user/bin"
 
-SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+readonly PREF_USE_DOWNLOADED="use-downloaded"
+readonly PREF_USE_INSTALLED="use-installed"
 
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 # Save original arguments in order to call 'kn' later seamlessly
 ORIGINAL_ARGS=( "$@" )
 
@@ -35,15 +37,21 @@ function error() {
   echo "error: $1" >&2
 }
 
+function save_preference() {
+  local PREF="$1"
+  echo "$PREF" > "$SCRIPT_DIR/kn-preferences"
+}
+
+function read_preferences() {
+  if [ -f "$SCRIPT_DIR/kn-preferences" ]; then
+    cat "$SCRIPT_DIR/kn-preferences"
+  fi
+}
+
 function call_actual_kn() {
   # Drop the script's directory from path to get the other installed kn
   PATH=${PATH/${SCRIPT_DIR}:/}
   kn "${ORIGINAL_ARGS[@]}"
-}
-
-function clean_up_wrapper_script() {
-  THIS_SCRIPT="${SCRIPT_DIR:?}/$(basename "$0")"
-  rm -rf "$THIS_SCRIPT"
 }
 
 function get_download_url() {
@@ -56,13 +64,16 @@ function get_download_url() {
 }
 
 function download_kn() {
+  if [ -x "$BINARIES_PATH/kn" ]; then
+    return
+  fi
   URL="$1"
   mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH"
   echo "Downloading kn from $URL"
-  curl "$URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" 
+  curl "$URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz"
   echo "Extracting kn CLI"
   tar -xf "$KN_DOWNLOAD_PATH/kn.tar.gz" -C "$KN_DOWNLOAD_PATH"
-  mv "$KN_DOWNLOAD_PATH/kn" "$BINARIES_PATH/"
+  mv "$KN_DOWNLOAD_PATH/kn" "$BINARIES_PATH/kn"
 }
 
 function prompt_user() {
@@ -77,11 +88,16 @@ function prompt_user() {
   echo ""
   if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
     download_kn "$KN_URL"
-    clean_up_wrapper_script
+    save_preference "$PREF_USE_DOWNLOADED"
   elif [[ "$OK" =~ ^(n|N|no|No) ]] ; then
-    clean_up_wrapper_script
+    save_preference "$PREF_USE_INSTALLED"
   fi
   call_actual_kn
 }
 
-prompt_user
+PREF=$(read_preferences)
+case "$PREF" in
+  "$PREF_USE_DOWNLOADED") download_kn; call_actual_kn ;;
+  "$PREF_USE_INSTALLED") call_actual_kn ;;
+  *) prompt_user ;;
+esac

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -316,8 +316,12 @@ function check_wrapper_arguments() {
 
 read_preferences
 
-# Check if we're running non-interactively
+# Check wrapper-specific arguments and handle them without running kn
 check_wrapper_arguments "$@"
+# Check if we're running interactively (if we have a stdin)
+if [ ! -t 0 ]; then
+  call_actual_kn
+fi
 
 # Shortcut if the user answered "no" to the prompt earlier; we don't to make unnecessary
 # API calls on every invocation of 'kn' unless necessary

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -29,9 +29,12 @@ readonly BINARIES_PATH="/home/user/bin"
 readonly PREF_USE_DOWNLOADED="use-downloaded"
 readonly PREF_USE_INSTALLED="use-installed"
 readonly PREF_CANNOT_DOWNLOAD="no-download"
+readonly DEVWORKSPACE_PREF_ANNOTATION="web-terminal.redhat.io/kn-wrapper-preference"
+readonly DEVWORKSPACE_PREF_ANNOTATION_ESCAPED="web-terminal\.redhat\.io/kn-wrapper-preference"
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
 readonly LOG_FILE="$SCRIPT_DIR/kn-wrapper.log"
+readonly PREFS_FILE="$SCRIPT_DIR/kn-wrapper-preferences"
 
 # Save original arguments in order to call 'kn' later seamlessly
 ORIGINAL_ARGS=( "$@" )
@@ -50,12 +53,25 @@ function info() {
 
 function save_preference() {
   local PREF="$1"
-  echo "$PREF" > "$SCRIPT_DIR/kn-preferences"
+  echo "$PREF" > "$PREFS_FILE"
+  info "Adding annotation to DevWorkspace to save download preference"
+  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" "$DEVWORKSPACE_PREF_ANNOTATION=$PREF" >>"$LOG_FILE" 2>&1
 }
 
 function read_preferences() {
-  if [ -f "$SCRIPT_DIR/kn-preferences" ]; then
-    cat "$SCRIPT_DIR/kn-preferences"
+  if [ -f "$PREFS_FILE" ]; then
+    cat "$PREFS_FILE"
+    return
+  fi
+  info "No preference file found, attempting to read preference from DevWorkspace annotations"
+  ANNOTATION_PREF=$(oc get dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" -o jsonpath="{.metadata.annotations.$DEVWORKSPACE_PREF_ANNOTATION_ESCAPED}" 2>>"$LOG_FILE")
+  if [ -n "$ANNOTATION_PREF" ]; then
+    # Save preference from workspace to file to avoid having to make API calls all the time
+    info "Read preference $ANNOTATION_PREF from DevWorkspace"
+    echo "$ANNOTATION_PREF" > "$PREFS_FILE"
+    echo "$ANNOTATION_PREF"
+  else
+    info "Could not find preference in DevWorkspace annotations"
   fi
 }
 

--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -63,6 +63,9 @@ readonly ARG_RESET_WRAPPER="--wto-reset-preferences"
 readonly ARG_RESTORE_PREFERENCES="--wto-restore-preferences"
 readonly ARG_PRINT_LOG="--wto-show-logs"
 
+# Path to cluster's certificate, to avoid warnings about untrusted certificates on some clusters
+readonly CACERT="${CACERT:-/var/run/secrets/kubernetes.io/serviceaccount/ca.crt}"
+
 # Env vars for preferences. These should be loaded from the $PREFS_FILE if it exists, or read from
 # the DevWorkspace annotations if not.
 declare PREF_SHOULD_DOWNLOAD
@@ -196,7 +199,7 @@ function download_kn() {
   cache_download_url
   mkdir -p "$KN_DOWNLOAD_PATH" "$BINARIES_PATH" >> "$LOG_FILE" 2>&1 || return 1
   info "Downloading kn from $KN_DOWNLOAD_URL"
-  curl "$KN_DOWNLOAD_URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" >> "$LOG_FILE" 2>&1 || return 1
+  curl --cacert "$CACERT" "$KN_DOWNLOAD_URL" -o "$KN_DOWNLOAD_PATH/kn.tar.gz" >> "$LOG_FILE" 2>&1 || return 1
   info "Downloaded kn archive to $KN_DOWNLOAD_PATH/kn.tar.gz"
   info "Extracting kn CLI to $KN_DOWNLOAD_PATH"
   tar -xf "$KN_DOWNLOAD_PATH/kn.tar.gz" -C "$KN_DOWNLOAD_PATH" >> "$LOG_FILE" 2>&1 || return 1

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -19,7 +19,7 @@ fi
 find "$INITIAL_CONFIG" -mindepth 1 -exec cp -nrp {} "${HOME}/" \;
 
 # Restore configuration of 'kn' wrapper if a user previously set a preference
-"$WRAPPER_BINARIES"/kn --wto-restore-preferences
+"$WRAPPER_BINARIES"/kn --wto-restore-preferences || true
 
 /tmp/get-tooling-versions.sh > /tmp/installed_tools.txt
 

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -21,4 +21,6 @@ find "$INITIAL_CONFIG" -mindepth 1 -exec cp -nrp {} "${HOME}/" \;
 # Restore configuration of 'kn' wrapper if a user previously set a preference
 "$WRAPPER_BINARIES"/kn --wto-restore-preferences
 
+/tmp/get-tooling-versions.sh > /tmp/installed_tools.txt
+
 exec "$@"

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -21,6 +21,7 @@ find "$INITIAL_CONFIG" -mindepth 1 -exec cp -nrp {} "${HOME}/" \;
 # Restore configuration of 'kn' wrapper if a user previously set a preference
 "$WRAPPER_BINARIES"/kn --wto-restore-preferences || true
 
-/tmp/get-tooling-versions.sh > /tmp/installed_tools.txt
+# Have to close stdin because odo will prompt for telemetry even in an entrypoint
+/tmp/get-tooling-versions.sh 0<&- > /tmp/installed_tools.txt
 
 exec "$@"

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -18,4 +18,7 @@ fi
 # Copy files in $INITIAL_CONFIG to $HOME without overwriting existing files
 find "$INITIAL_CONFIG" -mindepth 1 -exec cp -nrp {} "${HOME}/" \;
 
+# Restore configuration of 'kn' wrapper if a user previously set a preference
+"$WRAPPER_BINARIES"/kn --wto-restore-preferences
+
 exec "$@"


### PR DESCRIPTION
### Description
This PR adds a wrapper, `kn`, which is placed earlier in the path than the already-installed `kn` CLI. When the user first runs `kn`, this wrapper runs instead and, if the cluster has the serverless operator installed, prompts the user to download the `kn` CLI served by the operator instead of using the local version. If the user agrees to download the CLI, it is downloaded and run instead of the installed version of `kn`.

If the user responds to the prompt with "yes" or "no" (i.e. doesn't leave it blank), this preference is saved to a file inside the container (for speed of access) and to an annotation `web-terminal.redhat.io/kn-wrapper-preference` (to persist the decision between terminal starts).

This PR also changes the entrypoint.sh of the container to call this wrapper and automatically re-download `kn` if that is the preference the user chose.

The goal of the wrapper is to be transparent to the user except when prompting is required. As a result, we take the following behavior:
* If the serverless operator is not installed on the cluster, or the current user can't read the download URL for any reason, we silently pass arguments to the wrapper to the already-installed `kn` CLI
* If the user responds n/N/no/No to the prompt, we save this preference and only ever call the already-installed CLI with arguments.
* If the user responds y/Y/yes/Yes to the prompt, we download (and re-download when the terminal restarts) the kn CLI and transparently call that in the future.

The wrapper hides three wrapper-specific arguments to make debugging easier:
```
  --wto-reset-preferences   - Reset any saved preferences and remove existing
                              downloaded 'kn' binary, if it exists.
  --wto-restore-preferences - Non-interactively read preferences and download
                              'kn' from the cluster if necessary. This is used
                              for initial setup when the Web Terminal starts.
  --wto-show-logs           - Print internal log file to standard out
```

### How to test
Changes from this PR as built as image `quay.io/amisevsk/web-terminal-tooling:kn-wrapper`. To test these changes, execute the following command in any running web terminal:
```bash
wtoctl set image quay.io/amisevsk/web-terminal-tooling:kn-wrapper
```
(preferably in a cluster with serverless installed, e.g. developer sandbox)

Then run the `kn` CLI in the terminal once it restarts.

### Gif
![kn-wrapper](https://github.com/redhat-developer/web-terminal-tooling/assets/16168279/20744ad9-f32c-4c00-93d9-9c180336add2)
