### PR TITLE
Add wrapper to `tkn` CLI to allow potentially downloading newer version from cluster

### DIFF
--- a/etc/cli-wrappers/kn
+++ b/etc/cli-wrappers/kn
@@ -139,7 +139,7 @@ function read_preferences() {
   fi
   # If we're not currently logged in to the OpenShift cluster, we can go no further. Instead, call kn directly to avoid
   # really confusing error cases.
-  if ! oc whoami -c >/dev/null 2>&1; then
+  if ! oc whoami -t >/dev/null 2>&1; then
     return
   fi
   info "No preference file found, attempting to read preference from DevWorkspace annotations"
@@ -354,7 +354,7 @@ fi
 
 # If we're not currently logged in to the OpenShift cluster, call kn immediately to avoid
 # really confusing error cases.
-if ! oc whoami -c >/dev/null 2>&1; then
+if ! oc whoami -t >/dev/null 2>&1; then
   call_actual_kn
 fi
 

--- a/etc/cli-wrappers/tkn
+++ b/etc/cli-wrappers/tkn
@@ -139,7 +139,7 @@ function read_preferences() {
   fi
   # If we're not currently logged in to the OpenShift cluster, we can go no further. Instead, call tkn directly to avoid
   # really confusing error cases.
-  if ! oc whoami -c >/dev/null 2>&1; then
+  if ! oc whoami -t >/dev/null 2>&1; then
     return
   fi
   info "No preference file found, attempting to read preference from DevWorkspace annotations"
@@ -358,7 +358,7 @@ fi
 
 # If we're not currently logged in to the OpenShift cluster, call tkn immediately to avoid
 # really confusing error cases.
-if ! oc whoami -c >/dev/null 2>&1; then
+if ! oc whoami -t >/dev/null 2>&1; then
   call_actual_tkn
 fi
 

--- a/etc/cli-wrappers/tkn
+++ b/etc/cli-wrappers/tkn
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2020-2023 Red Hat, Inc.
+# Copyright (c) 2020-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -43,7 +43,7 @@ readonly PLATFORM="linux"
 readonly ARCH="amd64"
 
 # Directories used in wrapper
-readonly TKN_DOWNLOAD_PATH="/tmp/cli-downloads" # TODO: should this be different?
+readonly TKN_DOWNLOAD_PATH="/tmp/cli-downloads"
 readonly BINARIES_PATH="${DOWNLOADED_BINARIES:-/home/user/bin}"
 
 # Internal preferences and constants

--- a/etc/cli-wrappers/tkn
+++ b/etc/cli-wrappers/tkn
@@ -1,0 +1,374 @@
+#!/bin/bash
+#
+# Copyright (c) 2020-2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+#
+# This script is meant to serve as a wrapper for the `tkn` CLI in order to
+# facilitate downloading and updated version of the CLI from the cluster.
+# It is meant to be placed in $PATH earlier than the actual `tkn` CLI in order
+# to prompt the user to download `tkn` instead of using the installed version.
+# The user's decision is saved, so they are only prompted once; subsequent calls
+# to this wrapper script will transparently call 'tkn' (downloaded or default)
+# with all provided arguments
+#
+# This wrapper does not output to stdout/stderr to avoid cluttering the terminal
+# (except when prompting the user to download the binary from the cluster). All
+# output is redirected to a log file named `tkn-wrapper.log` in the script's
+# directory
+#
+# This wrapper script takes two wrapper-specific arguments to facilitate easier
+# setup:
+#   --wto-reset-preferences   - Reset any saved preferences and remove existing
+#                               downloaded 'tkn' binary, if it exists.
+#   --wto-restore-preferences - Non-interactively read preferences and download
+#                               'tkn' from the cluster if necessary. This is used
+#                               for initial setup when the Web Terminal starts.
+#   --wto-show-logs           - Print internal log file to standard out
+#
+
+set -e
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" || exit; pwd)
+
+readonly PLATFORM="linux"
+readonly ARCH="amd64"
+
+# Directories used in wrapper
+readonly TKN_DOWNLOAD_PATH="/tmp/cli-downloads" # TODO: should this be different?
+readonly BINARIES_PATH="${DOWNLOADED_BINARIES:-/home/user/bin}"
+
+# Internal preferences and constants
+readonly VAL_USE_DOWNLOADED="use-downloaded"
+readonly VAL_USE_INSTALLED="use-installed"
+readonly VAL_CANNOT_DOWNLOAD="no-download"
+readonly ANNOTATION_PREF_SHOULD_DOWNLOAD="web-terminal.redhat.io/tkn-wrapper-should-download"
+readonly ANNOTATION_PREF_DOWNLOAD_URL="web-terminal.redhat.io/tkn-wrapper-download-url"
+
+# Paths for storing logs and preferences
+readonly LOG_FILE="$SCRIPT_DIR/tkn-wrapper.log"
+readonly PREFS_FILE="$SCRIPT_DIR/tkn-wrapper.preferences"
+
+# Wrapper-specific arguments, prefixed by 'wto' to avoid colliding with any arguments
+# in the wrapped binary
+readonly ARG_RESET_WRAPPER="--wto-reset-preferences"
+readonly ARG_RESTORE_PREFERENCES="--wto-restore-preferences"
+readonly ARG_PRINT_LOG="--wto-show-logs"
+
+# Path to cluster's certificate, to avoid warnings about untrusted certificates on some clusters
+readonly CACERT="${CACERT:-/var/run/secrets/kubernetes.io/serviceaccount/ca.crt}"
+
+# Env vars for preferences. These should be loaded from the $PREFS_FILE if it exists, or read from
+# the DevWorkspace annotations if not.
+declare PREF_SHOULD_DOWNLOAD
+declare PREF_DOWNLOAD_URL
+
+# Cached download URL to avoid making multiple API calls
+declare TKN_DOWNLOAD_URL
+
+# Save original arguments in order to call 'tkn' seamlessly later
+ORIGINAL_ARGS=( "$@" )
+
+function internal_args_help() {
+  cat <<EOF
+Supported internal arguments:
+  --wto-reset-preferences   - Reset any saved preferences and remove existing
+                              downloaded 'tkn' binary, if it exists.
+  --wto-restore-preferences - Non-interactively read preferences and download
+                              'tkn' from the cluster if necessary. This is used
+                              for initial setup when the Web Terminal starts.
+  --wto-show-logs           - Print internal log file to standard out
+EOF
+}
+
+# Call the wrapped 'tkn' binary using the originally-provided arguments
+function call_actual_tkn() {
+  # Drop the script's directory from path to get the _other_ installed tkn
+  PATH=${PATH/${SCRIPT_DIR}:/}
+  tkn "${ORIGINAL_ARGS[@]}"
+  exit 0
+}
+
+# Log message with timestamp and error tag to the internal log file
+function error() {
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo -e "[$timestamp ERROR] $1" >> "$LOG_FILE"
+}
+
+# Log message with timestamp and info tag to the internal log file
+function info() {
+  local timestamp
+  timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  echo -e "[$timestamp INFO ] $1" >> "$LOG_FILE"
+}
+
+# Print a message to the user (error or informational). Message is printed to
+# stderr
+function message() {
+  echo "$@" >&2
+}
+
+# Save user preferences to file and DevWorkspace annotations
+function save_preferences() {
+  echo PREF_SHOULD_DOWNLOAD="${PREF_SHOULD_DOWNLOAD}" > "$PREFS_FILE"
+  echo PREF_DOWNLOAD_URL="${PREF_DOWNLOAD_URL}" >> "$PREFS_FILE"
+  info "Saved preferences:\n$(sed 's|^|    |' "$PREFS_FILE")"
+  info "Adding annotations to DevWorkspace to save preferences between restarts"
+  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" --overwrite \
+    "${ANNOTATION_PREF_SHOULD_DOWNLOAD}=${PREF_SHOULD_DOWNLOAD}" \
+    "${ANNOTATION_PREF_DOWNLOAD_URL}=${PREF_DOWNLOAD_URL}" \
+    >>"$LOG_FILE" 2>&1
+}
+
+# Read preferences. If preference file exists, set preferences from file; otherwise, read from DevWorkspace annotations on cluster
+# If preference is read from DevWorkspace, save this preference to the preference file to speed up future calls.
+function read_preferences() {
+  if [ -f "$PREFS_FILE" ]; then
+    # shellcheck source=/dev/null
+    source "${PREFS_FILE}"
+    return
+  fi
+  # If we're not currently logged in to the OpenShift cluster, we can go no further. Instead, call tkn directly to avoid
+  # really confusing error cases.
+  if ! oc whoami -c >/dev/null 2>&1; then
+    return
+  fi
+  info "No preference file found, attempting to read preference from DevWorkspace annotations"
+
+  local dw_json
+  dw_json=$(oc get dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" -o json 2>>"$LOG_FILE")
+  PREF_SHOULD_DOWNLOAD=$(echo "$dw_json" | jq -r --arg ANNOT "$ANNOTATION_PREF_SHOULD_DOWNLOAD" '.metadata.annotations[$ANNOT] // ""')
+  PREF_DOWNLOAD_URL=$(echo "$dw_json" | jq -r --arg ANNOT "$ANNOTATION_PREF_DOWNLOAD_URL" '.metadata.annotations[$ANNOT] // ""')
+
+  # Save results to file to avoid API calls later
+  echo PREF_SHOULD_DOWNLOAD="${PREF_SHOULD_DOWNLOAD}" > "$PREFS_FILE"
+  echo PREF_DOWNLOAD_URL="${PREF_DOWNLOAD_URL}" >> "$PREFS_FILE"
+  info "Read preferences from DevWorkspace:\n$(sed 's|^|    |' "$PREFS_FILE")"
+}
+
+# Reset any saved preferences (both in the preferences file and DevWorkspace annotations) and remove downloaded 'tkn'
+# binary, if present
+function reset_wrapper() {
+  info "Resetting tkn download preference and removing downloaded binary"
+  rm -rf "$PREFS_FILE"
+  rm -rf "$BINARIES_PATH/tkn"
+  rm -rf "$BINARIES_PATH/tkn-pac"
+  rm -rf "$BINARIES_PATH/opc"
+  oc annotate dw "$DEVWORKSPACE_NAME" -n "$DEVWORKSPACE_NAMESPACE" \
+    "${ANNOTATION_PREF_SHOULD_DOWNLOAD}-" \
+    "${ANNOTATION_PREF_DOWNLOAD_URL}-" \
+    >>"$LOG_FILE" 2>&1
+}
+
+# Try to read download URL from ConsoleCLIDownloads custom resources on the cluster. If we cannot get a URL for tkn,
+# returns status code 1; otherwise, prints the URL. This function is relatively slow due to the API calls; function
+# cache_download_url() should be used instead in most cases.
+function get_download_url() {
+  if ! oc auth can-i get consoleclidownloads --all-namespaces -q 2>>"$LOG_FILE"; then
+    error "Current user cannot get consoleclidownloads"
+    return 1
+  fi
+  CLI_DOWNLOAD_JSON=$(oc get consoleclidownloads tkn -o json 2>>"$LOG_FILE")
+  if [ -z "$CLI_DOWNLOAD_JSON" ]; then
+    error "ConsoleCLIDownload 'tkn' not found"
+    return 1
+  fi
+  URL=$(echo "$CLI_DOWNLOAD_JSON" | jq -r '.spec.links[].href' 2>>"$LOG_FILE"| grep "$PLATFORM" | grep "$ARCH")
+  if [ -z "$URL" ]; then
+    error "Could not get URL for 'tkn' CLI"
+    return 1
+  fi
+  info "Found consoleclidownload for tkn with URL $URL"
+  echo "$URL"
+}
+
+# Lazy-load the download URL for the tkn binary. If we haven't already loaded it, attempt to read the URL from the cluster
+# via get_download_url(). After calling this function $TKN_DOWNLOAD_URL stores the URL for downloading, or is empty if
+# tkn cannot be downloaded
+function cache_download_url() {
+  # We have to be careful here; the URL can either be an actual URL or empty if e.g. tkn is not available on the cluster
+  # Variable expansion '${VAR+set}' will be empty only if the variable is unset or null
+  if [ -z "${TKN_DOWNLOAD_URL+set}" ]; then
+    # URL is still unset (i.e. this is the first call to this function). Try to read URL from cluster
+    if ! TKN_DOWNLOAD_URL=$(get_download_url); then
+      # We can't get a download URL
+      TKN_DOWNLOAD_URL=""
+    fi
+  fi
+}
+
+# Download and extract tkn CLI from cluster. Downloaded CLI is saved to $BINARIES_PATH. Logs issues to $LOG_FILE and
+# returns 1 on error.
+function download_tkn() {
+  cache_download_url
+  mkdir -p "$TKN_DOWNLOAD_PATH" "$BINARIES_PATH" >> "$LOG_FILE" 2>&1 || return 1
+  info "Downloading tkn from $TKN_DOWNLOAD_URL"
+  curl --cacert "$CACERT" "$TKN_DOWNLOAD_URL" -o "$TKN_DOWNLOAD_PATH/tkn.tar.gz" >> "$LOG_FILE" 2>&1 || return 1
+  info "Downloaded tkn archive to $TKN_DOWNLOAD_PATH/tkn.tar.gz"
+  info "Extracting tkn CLI to $TKN_DOWNLOAD_PATH"
+  tar -xf "$TKN_DOWNLOAD_PATH/tkn.tar.gz" -C "$TKN_DOWNLOAD_PATH" >> "$LOG_FILE" 2>&1 || return 1
+  info "Extracted tkn CLI to $TKN_DOWNLOAD_PATH"
+  mv "$TKN_DOWNLOAD_PATH/tkn" "$BINARIES_PATH/tkn" || return 1
+  mv "$TKN_DOWNLOAD_PATH/tkn-pac" "$BINARIES_PATH/tkn-pac" || return 1
+  mv "$TKN_DOWNLOAD_PATH/opc" "$BINARIES_PATH/opc" || return 1
+  info "Moved tkn, tkn-pac, opc CLIs to $BINARIES_PATH/"
+}
+
+# Interactively prompt the user whether they want to download the 'tkn' binary from the cluster before
+# continuing. If the user responds yes or no, this preference is saved for future use (if the user provides no
+# response, no download is performed and the preference is _not_ saved)
+function prompt_user() {
+  cache_download_url
+  info "Prompting user to download 'tkn' from cluster"
+  message "Detected OpenShift Pipelines installation in this cluster."
+  message "The 'tkn' CLI is available at: $TKN_DOWNLOAD_URL"
+  read -rp "Would you like to automatically download 'tkn' from this URL instead of using the built-in version? (y/N): " OK
+  message ""
+  info "Received response '$OK' for prompt"
+  if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
+    if ! download_tkn; then
+      message "Failed to download CLI. See log file $LOG_FILE for details"
+      exit 1
+    fi
+    PREF_SHOULD_DOWNLOAD="$VAL_USE_DOWNLOADED"
+    PREF_DOWNLOAD_URL="$TKN_DOWNLOAD_URL"
+    save_preferences
+  elif [[ "$OK" =~ ^(n|N|no|No) ]] ; then
+    PREF_SHOULD_DOWNLOAD="$VAL_USE_INSTALLED"
+    save_preferences
+  fi
+}
+
+function handle_download_restore() {
+  info "Restoring cluster download for 'tkn' binary"
+  cache_download_url
+  if [ -z "$TKN_DOWNLOAD_URL" ]; then
+    info "Wrapper is configured to download 'tkn' but cannot find URL"
+    message "Warning: Web Terminal was previously configured to download 'tkn' from the cluster, but is unable to complete the download."
+    message "         Using built-in version -- see log file $LOG_FILE for more details."
+    message ""
+    call_actual_tkn
+  fi
+  if [ -n "$PREF_DOWNLOAD_URL" ] && [ "$TKN_DOWNLOAD_URL" != "$PREF_DOWNLOAD_URL" ]; then
+    # We don't want to continue automatically downloading if the URL changes, to avoid unexpected results
+    info "Wrapper is configured to download 'tkn' but URL has changed (new URL: $TKN_DOWNLOAD_URL)"
+    message "Warning: Web Terminal was previously configured to download 'tkn' from the cluster, but the URL for downloading 'tkn' has changed."
+    message "  Previous URL: $PREF_DOWNLOAD_URL"
+    message "  New URL:      $TKN_DOWNLOAD_URL"
+    read -rp "Would you like to update the URL used to download 'tkn'? (y/N): " OK
+    info "Received response $OK for update URL prompt"
+    if [[ "$OK" =~ ^(y|Y|yes|Yes) ]] ; then
+      PREF_DOWNLOAD_URL="$TKN_DOWNLOAD_URL"
+      save_preferences
+    else
+      # If user doesn't want to update the URL, then default to "use built-in version"
+      message "Saving preference and using built-in version of 'tkn'"
+      PREF_SHOULD_DOWNLOAD="$VAL_USE_INSTALLED"
+      save_preferences
+      call_actual_tkn
+    fi
+  fi
+  if ! download_tkn; then
+    message "Failed to download 'tkn' CLI. See log file $LOG_FILE for details."
+    PREF_SHOULD_DOWNLOAD="$VAL_CANNOT_DOWNLOAD"
+    save_preferences
+  fi
+}
+
+# Check arguments specific to this wrapper script; these are useful for debugging and initial setup.
+function check_wrapper_arguments() {
+  if [[ $# != 1 ]]; then
+    return
+  fi
+  case "$1" in
+    "$ARG_RESET_WRAPPER")
+      reset_wrapper
+      exit 0
+    ;;
+    "$ARG_RESTORE_PREFERENCES")
+      if [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_USE_DOWNLOADED" ]; then
+        info "Restoring preference $PREF_SHOULD_DOWNLOAD in initial setup"
+        cache_download_url
+        if [ -z "$TKN_DOWNLOAD_URL" ]; then
+          error "Could not detect URL for downloading tkn from cluster"
+          exit 0
+        fi
+        if [ -z "$PREF_DOWNLOAD_URL" ]; then
+          error "Could not find URL to redownload 'tkn'"
+          exit 0
+        fi
+        if [ "$PREF_DOWNLOAD_URL" != "$TKN_DOWNLOAD_URL" ]; then
+          error "Detected URL $TKN_DOWNLOAD_URL does not match previous URL $PREF_DOWNLOAD_URL"
+          exit 0
+        fi
+        if ! download_tkn; then
+          error "Could not redownload 'tkn' CLI"
+          exit 0
+        fi
+        info "Redownloaded tkn CLI from $TKN_DOWNLOAD_URL"
+      fi
+      exit 0
+    ;;
+    "$ARG_PRINT_LOG")
+      cat "$LOG_FILE"
+      exit 0
+    ;;
+    --wto-*)
+      message "Invalid wrapper argument $1"
+      internal_args_help
+      exit 1
+  esac
+}
+
+read_preferences
+
+# Check wrapper-specific arguments and handle them without running tkn
+check_wrapper_arguments "$@"
+# Check if we're running interactively (if we have a stdin) and if output is to stdout (or a pipe)
+# If we're in either case (non-interactive or piped) don't prompt and just call whatever tkn we've got.
+if [ ! -t 0 ] || [ ! -t 1 ]; then
+  call_actual_tkn
+fi
+
+# Shortcut if the user answered "no" to the prompt earlier; we don't to make unnecessary
+# API calls on every invocation of 'tkn' unless necessary
+if [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_CANNOT_DOWNLOAD" ] || [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_USE_INSTALLED" ]; then
+  call_actual_tkn
+fi
+
+if [ "$PREF_SHOULD_DOWNLOAD" == "$VAL_USE_DOWNLOADED" ]; then
+  # Shortcut if the user answered "yes" to the prompt and tkn is already downloaded. Assume
+  # we don't need to do anything.
+  if [ -x "$BINARIES_PATH/tkn" ]; then
+    call_actual_tkn
+  fi
+  # If 'tkn' doesn't exist, attempt to download it
+  handle_download_restore
+  call_actual_tkn
+fi
+
+# If we're not currently logged in to the OpenShift cluster, call tkn immediately to avoid
+# really confusing error cases.
+if ! oc whoami -c >/dev/null 2>&1; then
+  call_actual_tkn
+fi
+
+# No preference set yet: we should prompt the user, if applicable
+cache_download_url
+if [ -n "$TKN_DOWNLOAD_URL" ]; then
+  prompt_user
+else
+  PREF_SHOULD_DOWNLOAD="$VAL_CANNOT_DOWNLOAD"
+  save_preferences
+fi
+
+call_actual_tkn

--- a/etc/entrypoint.sh
+++ b/etc/entrypoint.sh
@@ -20,6 +20,8 @@ find "$INITIAL_CONFIG" -mindepth 1 -exec cp -nrp {} "${HOME}/" \;
 
 # Restore configuration of 'kn' wrapper if a user previously set a preference
 "$WRAPPER_BINARIES"/kn --wto-restore-preferences || true
+# Restore configuration of 'tkn' wrapper if a user previously set a preference
+"$WRAPPER_BINARIES"/tkn --wto-restore-preferences || true
 
 # Have to close stdin because odo will prompt for telemetry even in an entrypoint
 /tmp/get-tooling-versions.sh 0<&- > /tmp/installed_tools.txt


### PR DESCRIPTION
### Description
This PR adds a wrapper for the `tkn` CLI, similar to the one used for the `kn` wrapper. See PR https://github.com/redhat-developer/web-terminal-tooling/pull/62 for details on wrapper implementation -- options and arguments are the same as in that PR.

I considered modifying the wrappers to try to extract some common functionality, but bash is hard enough to read as it is, so the `tkn` wrapper script is largely a copy-paste of the `kn` wrapper script, changed slightly to accomodate differences between the two (e.g. the `tkn` tarball comes with three CLIs).

This PR also fixes a minor bug introduced by https://github.com/redhat-developer/web-terminal-tooling/pull/65 that caused the wrappers to not automatically redownload CLIs on start, resulting in a slight delay before calling `kn`/`tkn` the first time.

### How to test
The changes from this PR are built and pushed as `quay.io/amisevsk/web-terminal-tooling:tkn-wrapper`. To test these changes, execute the following command in any running web terminal:
```
wtoctl set image quay.io/amisevsk/web-terminal-tooling:tkn-wrapper
```
(see e.g the Developer Sandbox, which has OpenShift Pipelines installed)