### PR TITLE
fix: add back oc zsh completion, remove odo zsh completion

### DIFF
--- a/etc/initial_config/.zshrc
+++ b/etc/initial_config/.zshrc
@@ -26,6 +26,9 @@ compinit
 if command -v kubectl &>/dev/null; then
   source <(kubectl completion zsh)
 fi
+if command -v oc &>/dev/null; then
+  source <(oc completion zsh)
+fi
 if command -v kn &>/dev/null; then
   source <(kn completion zsh)
 fi
@@ -43,9 +46,6 @@ if command -v rhoas &>/dev/null; then
 fi
 if command -v subctl &>/dev/null; then
   source <(subctl completion zsh)
-fi
-if command -v odo &>/dev/null; then
-  source <(odo completion zsh)
 fi
 
 PROMPT='%1N %~ %# '


### PR DESCRIPTION
Fixes redhat-developer/web-terminal-operator#174

# Testing
1. Build the web terminal tooling image based off of this PR. I've pushed to `quay.io/aobuchow/wto-tooling:zsh-completion-fix` for convenience
2. Create a web terminal using the image based off of this PR (`quay.io/aobuchow/wto-tooling:zsh-completion-fix`)
3. Once your web terminal starts up, run `zsh`.
4. With the zsh shell started, type in `oc g` and hit the TAB key. It should complete to `oc get`