### PR TITLE
chore : Add Devfile for web-terminal-exec with Makefile-based workflow commands

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -10,7 +10,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-schemaVersion: 2.2.0
+schemaVersion: 2.3.0
 metadata:
   name: web-terminal-tooling
 components:

--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,44 @@
+#
+# Copyright (c) 2019-2025 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+schemaVersion: 2.2.0
+metadata:
+  name: web-terminal-tooling
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi9-latest
+      memoryRequest: 1Gi
+      memoryLimit: 16Gi
+      cpuLimit: '4'
+      cpuRequest: '0.5'
+      env:
+        - name: DOCKER
+          value: podman
+commands:
+  - id: help
+    exec:
+      label: "List available build options"
+      component: tools
+      commandLine: bash build.sh --help
+      group:
+        kind: build 
+  - id: build
+    exec:
+      label: "Build container image"
+      component: tools
+      commandLine: |
+        read -p "ENTER a image name and tag for container builds (default is quay.io/wto/web-terminal-tooling:next): " TARGET_IMG &&
+        export WEB_TERMINAL_TOOLING_IMG=${TARGET_IMG}
+        bash build.sh -u
+      group:
+        kind: build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,11 @@ RUN mkdir -p /home/user $INITIAL_CONFIG $WRAPPER_BINARIES $DOWNLOADED_BINARIES &
     tar git procps jq && \
     microdnf -y clean all
 
-ADD container-root-x86_64.tgz /
+COPY container-root-x86_64.tgz /tmp/container-root-x86_64.tgz
+
+RUN tar --no-same-owner -xzf /tmp/container-root-x86_64.tgz -C / && \
+    rm /tmp/container-root-x86_64.tgz
+
 # Propagate tools to path and install bash autocompletion
 RUN \
     COMPDIR=$(pkg-config --variable=completionsdir bash-completion) && \


### PR DESCRIPTION
## Description

+ Add Devfile that sets up a development environment using the universal developer image,
  and includes Makefile-based commands
+ When I was testing this devfile in workspaces.openshift.com, I was seeing this error:
```
Error: building at STEP "ADD container-root-x86_64.tgz /": 3 errors occurred:
        * reading "/projects/web-terminal-tooling/container-root-x86_64.tgz": error during bulk transfer for copier.request{Request:"GET", Root:"/", preservedRoot:"/projects/web-terminal-tooling", rootPrefix:"/projects/web-terminal-tooling", Directory:"/", preservedDirectory:"/projects/web-terminal-tooling", Globs:[]string{"/container-root-x86_64.tgz"}, preservedGlobs:[]string{"/projects/web-terminal-tooling/container-root-x86_64.tgz"}, StatOptions:copier.StatOptions{CheckForArchives:true, Excludes:[]string(nil)}, GetOptions:copier.GetOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), Excludes:[]string(nil), ExpandArchives:true, ChownDirs:(*idtools.IDPair)(0xc00059b2c0), ChmodDirs:(*fs.FileMode)(nil), ChownFiles:(*idtools.IDPair)(0xc00059b2d0), ChmodFiles:(*fs.FileMode)(nil), StripSetuidBit:true, StripSetgidBit:true, StripStickyBit:false, StripXattrs:false, KeepDirectoryNames:false, Rename:map[string]string(nil), NoDerefSymlinks:false, IgnoreUnreadable:false, NoCrossDevice:false}, PutOptions:copier.PutOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), DefaultDirOwner:(*idtools.IDPair)(nil), DefaultDirMode:(*fs.FileMode)(nil), ChownDirs:(*idtools.IDPair)(nil), ChmodDirs:(*fs.FileMode)(nil), ChownFiles:(*idtools.IDPair)(nil), ChmodFiles:(*fs.FileMode)(nil), StripSetuidBit:false, StripSetgidBit:false, StripStickyBit:false, StripXattrs:false, IgnoreXattrErrors:false, IgnoreDevices:false, NoOverwriteDirNonDir:false, NoOverwriteNonDirDir:false, Rename:map[string]string(nil)}, MkdirOptions:copier.MkdirOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), ChownNew:(*idtools.IDPair)(nil), ChmodNew:(*fs.FileMode)(nil)}, RemoveOptions:copier.RemoveOptions{All:false}}: copier: get: "/container-root-x86_64.tgz": extracting content from archive /container-root-x86_64.tgz: ./opt/rhoas/rhoas: write bulk-writer: broken pipe
        * closing "/projects/web-terminal-tooling/container-root-x86_64.tgz": reading tar archive: copying content for "./opt/rhoas/CHANGELOG.md": io: read/write on closed pipe
        * storing "/projects/web-terminal-tooling/container-root-x86_64.tgz": error during bulk transfer for copier.request{Request:"PUT", Root:"/", preservedRoot:"/home/user/.local/share/containers/storage/vfs/dir/95703ebd54ccb699d7a794e647bc1326a0a840fff34f24b926ec51469891663f", rootPrefix:"/home/user/.local/share/containers/storage/vfs/dir/95703ebd54ccb699d7a794e647bc1326a0a840fff34f24b926ec51469891663f", Directory:"/", preservedDirectory:"/home/user/.local/share/containers/storage/vfs/dir/95703ebd54ccb699d7a794e647bc1326a0a840fff34f24b926ec51469891663f", Globs:[]string{}, preservedGlobs:[]string{}, StatOptions:copier.StatOptions{CheckForArchives:false, Excludes:[]string(nil)}, GetOptions:copier.GetOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), Excludes:[]string(nil), ExpandArchives:false, ChownDirs:(*idtools.IDPair)(nil), ChmodDirs:(*fs.FileMode)(nil), ChownFiles:(*idtools.IDPair)(nil), ChmodFiles:(*fs.FileMode)(nil), StripSetuidBit:false, StripSetgidBit:false, StripStickyBit:false, StripXattrs:false, KeepDirectoryNames:false, Rename:map[string]string(nil), NoDerefSymlinks:false, IgnoreUnreadable:false, NoCrossDevice:false}, PutOptions:copier.PutOptions{UIDMap:[]idtools.IDMap{}, GIDMap:[]idtools.IDMap{}, DefaultDirOwner:(*idtools.IDPair)(0xc0004a9280), DefaultDirMode:(*fs.FileMode)(nil), ChownDirs:(*idtools.IDPair)(nil), ChmodDirs:(*fs.FileMode)(nil), ChownFiles:(*idtools.IDPair)(nil), ChmodFiles:(*fs.FileMode)(nil), StripSetuidBit:false, StripSetgidBit:false, StripStickyBit:false, StripXattrs:false, IgnoreXattrErrors:false, IgnoreDevices:true, NoOverwriteDirNonDir:false, NoOverwriteNonDirDir:false, Rename:map[string]string(nil)}, MkdirOptions:copier.MkdirOptions{UIDMap:[]idtools.IDMap(nil), GIDMap:[]idtools.IDMap(nil), ChownNew:(*idtools.IDPair)(nil), ChmodNew:(*fs.FileMode)(nil)}, RemoveOptions:copier.RemoveOptions{All:false}}: copier: put: error setting ownership of "/" to 1000660000:1000660000: lchown /: invalid argument
```
This line caused it:
https://github.com/redhat-developer/web-terminal-tooling/blob/9024ad39622e36e687f6c07b6f78cdd67aa391be/Dockerfile#L28

  Replaced `ADD` directive with `COPY` followed by `tar -xzf --no-same-owner`
    to prevent ownership-related extraction failures. This avoids errors caused
    by unsupported UID/GID values in the archive when building with Podman.


Signed-off-by: Rohan Kumar <rohaan@redhat.com>